### PR TITLE
Harden Hydra percentile normalization safety semantics

### DIFF
--- a/execution/hydra_engine.py
+++ b/execution/hydra_engine.py
@@ -1570,7 +1570,19 @@ def percentile_normalize_scores(
                 pass
 
     n = len(scores)
-    if n < 2:
+    if n == 0:
+        return
+
+    # Preserve pre-normalized score for research/analytics before overwrite.
+    for pos, intent_idx in enumerate(indices):
+        intents[intent_idx].setdefault("raw_score", round(scores[pos], 6))
+
+    if n == 1:
+        # Deterministic singleton behavior: map to midpoint percentile.
+        mid = clamp_lo + (clamp_hi - clamp_lo) * 0.5
+        intent_idx = indices[0]
+        intents[intent_idx][score_key] = round(mid, 6)
+        intents[intent_idx]["hybrid_score"] = round(mid, 6)
         return
 
     # Build rank → percentile mapping (handles ties via average rank)

--- a/tests/unit/test_percentile_normalize.py
+++ b/tests/unit/test_percentile_normalize.py
@@ -48,10 +48,20 @@ class TestPercentileNormalize:
         assert scores[0] == pytest.approx(0.02, abs=0.001)
         assert scores[-1] == pytest.approx(0.98, abs=0.001)
 
-    def test_single_intent_unchanged(self):
+    def test_single_intent_midpoint(self):
         intents = [{"score": 0.75}]
         percentile_normalize_scores(intents)
-        assert intents[0]["score"] == 0.75
+        assert intents[0]["score"] == pytest.approx(0.5, abs=0.001)
+        assert intents[0]["hybrid_score"] == pytest.approx(0.5, abs=0.001)
+
+    def test_raw_score_preserved_before_normalization(self):
+        intents = [
+            {"score": 0.40},
+            {"score": 0.60},
+        ]
+        percentile_normalize_scores(intents)
+        assert intents[0]["raw_score"] == pytest.approx(0.40, abs=0.001)
+        assert intents[1]["raw_score"] == pytest.approx(0.60, abs=0.001)
 
     def test_empty_list_no_crash(self):
         intents: list = []


### PR DESCRIPTION
### Motivation
- Prevent edge cases in Hydra percentile normalization that could break diagnostics or downstream observability when a batch has zero or one scored intent.  
- Preserve original numeric research artifacts so downstream analytics can access pre-normalized `score` values.  
- Ensure deterministic, stable behavior for ties and singleton batches so monotonicity and funnel diagnostics remain reproducible.

### Description
- Updated `percentile_normalize_scores` in `execution/hydra_engine.py` to return early on zero scores and to preserve a pre-normalized `raw_score` for every scored intent before any overwrite by normalization.  
- Implemented deterministic singleton handling (`n == 1`) to map a single scored intent to the midpoint percentile derived from `clamp_lo`/`clamp_hi` and stamp `hybrid_score` consistently.  
- Left existing tie-handling (average-rank assignment) intact so percentile assignment remains deterministic and stable for equal raw scores.  
- Added unit tests in `tests/unit/test_percentile_normalize.py` to cover singleton midpoint behavior and `raw_score` preservation, and updated the existing single-intent test.

### Testing
- Ran `pytest -q tests/unit/test_percentile_normalize.py` and all tests passed (12 tests, green).  
- Existing tie, clamping, spread-expansion, missing-score, hybrid stamping, and non-dict skipping tests were retained and continue to pass under the modified logic.  
- The change is narrowly scoped to in-batch percentile normalization and does not modify `expected_edge` or `conviction_score` fields consumed by the fee gate, doctrine, or edge calibration paths (these consumers continue to read their dedicated fields).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c624691c8323ad9793bd293b9214)