### PR TITLE
Harden dashboard optional panel imports and add smoke test coverage

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -106,19 +106,33 @@ from dashboard.components.architecture_strip import (
 )
 
 # Edge Calibration
-from dashboard.components.edge_calibration_panel import (
-    render_edge_calibration_panel,
-)
+try:
+    from dashboard.components.edge_calibration_panel import (
+        render_edge_calibration_panel,
+    )
+except Exception:  # pragma: no cover - defensive import fallback
+    def render_edge_calibration_panel(*_args: Any, **_kwargs: Any) -> None:
+        return
+
 
 # Engine Lift (Hydra vs Legacy)
-from dashboard.components.engine_lift_panel import (
-    render_engine_lift_panel,
-)
+try:
+    from dashboard.components.engine_lift_panel import (
+        render_engine_lift_panel,
+    )
+except Exception:  # pragma: no cover - defensive import fallback
+    def render_engine_lift_panel(*_args: Any, **_kwargs: Any) -> None:
+        return
+
 
 # Hydra Score Monotonicity
-from dashboard.components.hydra_monotonicity_panel import (
-    render_hydra_monotonicity_panel,
-)
+try:
+    from dashboard.components.hydra_monotonicity_panel import (
+        render_hydra_monotonicity_panel,
+    )
+except Exception:  # pragma: no cover - defensive import fallback
+    def render_hydra_monotonicity_panel(*_args: Any, **_kwargs: Any) -> None:
+        return
 
 # Multi-Engine Soak Panel
 from dashboard.multi_engine_panel import render_multi_engine_panel

--- a/tests/unit/test_dashboard_smoke.py
+++ b/tests/unit/test_dashboard_smoke.py
@@ -46,6 +46,13 @@ class TestDashboardSmoke:
         ):
             assert callable(fn)
 
+    def test_optional_panel_imports_are_guarded(self):
+        from pathlib import Path
+        source = Path("dashboard/app.py").read_text()
+        assert "try:\n    from dashboard.components.edge_calibration_panel import" in source
+        assert "try:\n    from dashboard.components.engine_lift_panel import" in source
+        assert "try:\n    from dashboard.components.hydra_monotonicity_panel import" in source
+
     def test_css_file_exists(self):
         from pathlib import Path
         css = Path("dashboard/static/quant_theme.css")


### PR DESCRIPTION
### Motivation
- Prevent the dashboard from crashing at startup when optional visualization panels are missing or raise import errors by providing defensive fallbacks and ensuring this contract is enforced by tests.
- Improve smoke-test coverage so future refactors don't accidentally remove the defensive import guards for optional panels.

### Description
- Wrapped imports for `edge_calibration_panel`, `engine_lift_panel`, and `hydra_monotonicity_panel` in `dashboard/app.py` in `try/except` blocks and added no-op fallback render functions to avoid import-time crashes.
- Added a smoke test `test_optional_panel_imports_are_guarded` in `tests/unit/test_dashboard_smoke.py` that asserts the guarded `try` import pattern exists in `dashboard/app.py`.

### Testing
- Ran `pytest -q tests/unit/test_dashboard_smoke.py` and all tests passed. 
- Verified the modified `dashboard/app.py` includes the defensive `try/except` imports and that `tests/unit/test_dashboard_smoke.py` now checks for those guards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1c6402a688323bf7f68894c50913a)