### PR TITLE
fix(execution): restore hybrid expectancy fee-gate propagation

### DIFF
--- a/execution/executor_live.py
+++ b/execution/executor_live.py
@@ -167,6 +167,8 @@ _V6_RUNTIME_PROBE_INTERVAL = float(os.getenv("V6_RUNTIME_PROBE_INTERVAL", "300")
 _LAST_V6_RUNTIME_PROBE = 0.0
 
 from execution.fallback_telemetry import FallbackTelemetry
+from execution.hybrid_component_propagation import trace_hybrid_component_propagation
+
 _FALLBACK_TELEMETRY = FallbackTelemetry()
 _PIPELINE_V6_HEARTBEAT_INTERVAL_S = float(os.getenv("PIPELINE_V6_SHADOW_HEARTBEAT_INTERVAL_S", "600") or 600)
 _LAST_PIPELINE_V6_HEARTBEAT = 0.0
@@ -1815,6 +1817,100 @@ def _normalize_intent(intent: Mapping[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
+def _hydra_route_trace(stage: str, intent: Mapping[str, Any], outcome: str = "ok", reason: str = "") -> None:
+    """Append-only routing telemetry for hydra-sourced intents (fail-open)."""
+    try:
+        if not isinstance(intent, Mapping):
+            return
+        src = str(intent.get("source") or "").lower()
+        if src != "hydra":
+            return
+        meta = intent.get("metadata") if isinstance(intent.get("metadata"), Mapping) else {}
+        heads = intent.get("strategy_heads") or meta.get("strategy_heads") or []
+        source_head = (heads[0] if isinstance(heads, (list, tuple)) and heads else None) or intent.get("strategy_id")
+        score_v = intent.get("score") or intent.get("hybrid_score") or meta.get("score") or meta.get("hybrid_score")
+        nav_pct_v = intent.get("nav_pct") or meta.get("nav_pct")
+        notional_v = (
+            intent.get("notional_usd")
+            or intent.get("gross_usd")
+            or intent.get("capital_per_trade")
+        )
+        append_jsonl(Path("logs/execution/hydra_route_trace.jsonl"), {
+            "ts": time.time(),
+            "symbol": intent.get("symbol"),
+            "side": intent.get("side") or intent.get("net_side") or intent.get("positionSide"),
+            "intent_id": intent.get("intent_id") or intent.get("attempt_id"),
+            "source_head": source_head,
+            "strategy": intent.get("strategy") or intent.get("strategy_id") or "hydra",
+            "score": score_v,
+            "nav_pct": nav_pct_v,
+            "projected_notional": float(notional_v) if notional_v is not None else None,
+            "stage": stage,
+            "outcome": outcome,
+            "reason": reason,
+        })
+    except Exception:
+        pass
+
+
+def _router_dispatch_trace(
+    stage: str,
+    intent: Mapping[str, Any] | None = None,
+    *,
+    outcome: str = "ok",
+    reason: str = "",
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    """Append-only trace for the executor → router → dispatch path.
+
+    Logging-only. Never raises. Records every intent that enters
+    ``_send_order`` and the stage at which it exits or proceeds. Lets us
+    pinpoint silent suppression between doctrine ALLOW and exchange
+    submission.
+
+    Stages: send_order_entered, router_route_called, dispatch_called,
+    exchange_submit_attempted, exchange_submit_success,
+    exchange_submit_failed, dropped_pre_router, dropped_pre_dispatch,
+    cooldown_skip, position_skip, dedupe_skip.
+    """
+    try:
+        intent_d = intent if isinstance(intent, Mapping) else {}
+        meta = intent_d.get("metadata") if isinstance(intent_d.get("metadata"), Mapping) else {}
+        rec: Dict[str, Any] = {
+            "ts": time.time(),
+            "stage": stage,
+            "outcome": outcome,
+            "reason": reason,
+            "symbol": intent_d.get("symbol"),
+            "side": (
+                intent_d.get("side")
+                or intent_d.get("signal")
+                or intent_d.get("net_side")
+                or intent_d.get("positionSide")
+            ),
+            "intent_id": intent_d.get("intent_id") or intent_d.get("attempt_id"),
+            "attempt_id": intent_d.get("attempt_id"),
+            "source": intent_d.get("source"),
+            "strategy": intent_d.get("strategy") or intent_d.get("strategy_id"),
+            "reduce_only": bool(intent_d.get("reduceOnly", False)),
+            "position_side": intent_d.get("positionSide"),
+            "qty": intent_d.get("quantity") or intent_d.get("qty"),
+            "notional": (
+                intent_d.get("gross_usd")
+                or intent_d.get("notional_usd")
+                or (meta.get("notional") if isinstance(meta, Mapping) else None)
+            ),
+        }
+        if extra:
+            for k, v in extra.items():
+                # avoid clobbering required fields
+                if k not in rec or rec[k] is None:
+                    rec[k] = v
+        append_jsonl(Path("logs/execution/router_dispatch_trace.jsonl"), rec)
+    except Exception:
+        pass
+
+
 def _intent_score_for_log(intent: Mapping[str, Any]) -> float:
     """Extract a comparable score from an intent for attribution logging."""
     for key in ("hybrid_score", "score"):
@@ -2491,6 +2587,81 @@ def _evaluate_order_risk(
         current_tier_gross_notional=current_tier_gross,
         source_head=source_head,
     )
+    # Telemetry: log risk-veto trace for sizing diagnostics (fail-open, no logic change)
+    if risk_veto:
+        try:
+            _trace_path = Path("logs/execution/risk_veto_trace.jsonl")
+            _price = float(intent.get("price") or 0.0)
+            _implied_qty = (gross_target / _price) if _price > 0 else None
+            _min_notional = None
+            try:
+                _min_notional = float(
+                    (details or {}).get("thresholds", {}).get("min_notional")
+                )
+            except Exception:
+                _min_notional = None
+            _reasons = []
+            try:
+                _reasons = list((details or {}).get("reasons") or [])
+            except Exception:
+                _reasons = []
+            _meta_local = (
+                intent.get("metadata")
+                if isinstance(intent.get("metadata"), dict)
+                else {}
+            )
+            _score = (
+                intent.get("hybrid_score")
+                or intent.get("score")
+                or _meta_local.get("hybrid_score")
+                or _meta_local.get("score")
+            )
+            _base_nav_pct = (
+                intent.get("nav_pct")
+                or _meta_local.get("nav_pct")
+                or _meta_local.get("base_nav_pct")
+            )
+            _cerb_mult = (
+                intent.get("cerberus_multiplier")
+                or _meta_local.get("cerberus_multiplier")
+            )
+            _implied_nav_pct = (
+                (gross_target / nav) if (nav and nav > 0) else None
+            )
+            append_jsonl(_trace_path, {
+                "ts": time.time(),
+                "symbol": symbol,
+                "side": side,
+                "intent_id": intent.get("intent_id"),
+                "attempt_id": intent.get("attempt_id"),
+                "strategy": intent.get("strategy") or intent.get("strategy_id"),
+                "source_head": source_head,
+                "tier": tier_name,
+                "risk_veto": True,
+                "veto_reasons": _reasons,
+                "min_notional_floor": _min_notional,
+                "requested_notional": float(gross_target),
+                "implied_nav_pct": _implied_nav_pct,
+                "implied_qty_from_price": _implied_qty,
+                "intent_qty": intent.get("qty"),
+                "price_hint": _price,
+                "nav_usd": float(nav),
+                "current_symbol_gross": float(current_symbol_gross),
+                "current_tier_gross": float(current_tier_gross),
+                "open_positions_count": int(open_positions_count),
+                "lev": float(lev),
+                "score": _score,
+                "intent_nav_pct_hint": _base_nav_pct,
+                "cerberus_multiplier_hint": _cerb_mult,
+                # Dead-band probe: required score for floor at given base/cerb/nav
+                "required_score_for_floor": (
+                    (_min_notional / (nav * float(_base_nav_pct or 0.02) * float(_cerb_mult or 1.0)))
+                    if (_min_notional and nav and nav > 0 and float(_base_nav_pct or 0.02) > 0 and float(_cerb_mult or 1.0) > 0)
+                    else None
+                ),
+            })
+        except Exception:
+            pass
     return risk_veto, details
 
 
@@ -3178,6 +3349,14 @@ def _check_fee_edge_gate(
         _fg_notional = gross_target
         _fg_meta = intent.get("metadata") or {}
         _fg_hybrid = intent.get("hybrid_components") or {}
+        trace_hybrid_component_propagation(
+            origin_stage="fee_gate_received",
+            intent=intent,
+            source_head=str(intent.get("source_head", "") or ""),
+            merge_path=str(intent.get("merge_path", "") or ""),
+            intent_type="fee_gate_input",
+            hybrid_components=_fg_hybrid,
+        )
 
         # ── Resolve intent expected_edge (conviction-derived) ─────────
         # Precedence: intent["expected_edge"] > hybrid expectancy > metadata
@@ -3207,9 +3386,17 @@ def _check_fee_edge_gate(
             _INTENT_EDGE_CAP = 0.25  # Cap at 25% to guard runaway values
             _te_result = None
 
+            # v7.9-FG-A: Accept any resolved intent expectancy source.
+            # Previously this branch only fired for "intent_expected_edge",
+            # silently dropping the hybrid_components.expectancy and
+            # metadata.expectancy values into the ATR fallback path.
             if (
                 _intent_edge_pct > 0
-                and _fg_edge_source == "intent_expected_edge"
+                and _fg_edge_source in (
+                    "intent_expected_edge",
+                    "hybrid_expectancy",
+                    "metadata_expectancy",
+                )
                 and _intent_edge_pct == _intent_edge_pct  # finite check (NaN != NaN)
             ):
                 from execution.true_edge import TrueEdgeResult
@@ -3223,7 +3410,7 @@ def _check_fee_edge_gate(
                     adv=round(_capped_edge, 6),
                     confidence=_te_confidence,
                     notional_usd=_fg_notional,
-                    source="intent_expected_edge",
+                    source=_fg_edge_source,
                 )
 
             # ── Fallback: ATR-based edge model ────────────────────────
@@ -3514,6 +3701,14 @@ def _check_notional_inflation_guard(
 
 # NOTE: _send_order must only pass canonical order fields into send_order.
 def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool = False) -> None:
+    _router_dispatch_trace("send_order_entered", intent, extra={"skip_flip": skip_flip})
+    trace_hybrid_component_propagation(
+        origin_stage="executor_received",
+        intent=intent,
+        source_head=str(intent.get("source_head", "") or ""),
+        merge_path=str(intent.get("merge_path", "") or ""),
+        intent_type="executor_input",
+    )
     # ZERO-SCORE INVARIANT — reject intents with explicit zero score (AUDIT-2.2a)
     _score = None
     _has_score_field = False
@@ -3540,6 +3735,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             })
         except Exception:
             pass
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason="zero_score",
+            extra={"score": _score},
+        )
         return
 
     # DOCTRINE GATE — Supreme Authority Check
@@ -3592,6 +3792,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
                 )
             except Exception as exc:
                 LOG.debug("[dle_shadow] entry_deny hook failed: %s", exc)
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason=f"doctrine_veto:{doctrine_reason}",
+            extra={"doctrine_details": doctrine_details},
+        )
         return  # Hard stop — no further processing
     
     # --- Hydra Funnel: stage 4 (post_doctrine) ---
@@ -3663,12 +3868,20 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             )
             if not cg_allowed:
                 LOG.info("[churn_guard] EXIT VETO %s %s: %s", symbol_upper, pos_side, cg_reason)
+                _router_dispatch_trace(
+                    "dropped_pre_router", intent,
+                    outcome="drop", reason=f"churn_guard_exit:{cg_reason}",
+                )
                 return
         else:
             # Entry gate: cooldown check
             cg_allowed, cg_reason = check_entry_allowed(symbol_upper, pos_side or "")
             if not cg_allowed:
                 LOG.info("[churn_guard] ENTRY VETO %s %s: %s", symbol_upper, pos_side, cg_reason)
+                _router_dispatch_trace(
+                    "cooldown_skip", intent,
+                    outcome="drop", reason=f"churn_guard_entry:{cg_reason}",
+                )
                 return
     except ImportError:
         # AUDIT-1.1e: churn_guard missing — log as disabled gate
@@ -3891,6 +4104,10 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             pos_side=pos_side,
             gross_target=gross_target,
         )
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason="no_strategy_attribution",
+        )
         return None
 
     # v7.9-S1: Conviction band gate.  If conviction.mode="live" and
@@ -3937,6 +4154,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
                         side=side,
                         pos_side=pos_side,
                         gross_target=gross_target,
+                    )
+                    _router_dispatch_trace(
+                        "dropped_pre_router", intent,
+                        outcome="drop", reason="conviction_band_below_minimum",
+                        extra={"band": _intent_band, "min_band": _min_band_str},
                     )
                     return None
                 else:
@@ -4005,6 +4227,10 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             )
         except Exception:
             pass
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason="kill_switch_on",
+        )
         return
 
     LOG.info(
@@ -4271,6 +4497,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             pos_side=pos_side,
             gross_target=gross_target,
         )
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason=f"risk_veto:{reason}",
+            extra={"reasons": reasons, "gross_target": gross_target},
+        )
         return
 
     price_hint = float(intent.get("price", 0.0) or 0.0)
@@ -4279,6 +4510,10 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             price_hint = float(get_price(symbol))
         except Exception as exc:
             LOG.error("[executor] price_fetch_err %s %s", symbol, exc)
+            _router_dispatch_trace(
+                "dropped_pre_router", intent,
+                outcome="drop", reason=f"price_fetch_err:{exc}",
+            )
             return
 
     # ── v7.9-E2: Fee-Aware Edge Gate (entries only) ───────────────────────
@@ -4293,6 +4528,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             intent_id=intent_id,
             attempt_id=attempt_id,
         ):
+            _router_dispatch_trace(
+                "dropped_pre_router", intent,
+                outcome="drop", reason="fee_edge_gate",
+                extra={"gross_target": gross_target},
+            )
             return
 
     # ── Sizing Snapshot: canonical pre-order audit record ──
@@ -4344,6 +4584,10 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             )
         except Exception:
             LOG.warning("[SIZE_ERROR_AUDIT] publish_order_audit failed for %s", symbol, exc_info=True)
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason=f"size_error:{exc}",
+        )
         return
 
     payload["positionSide"] = pos_side
@@ -4361,6 +4605,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
         intent=intent,
         nav_snapshot=nav_snapshot,
     ):
+        _router_dispatch_trace(
+            "dropped_pre_router", intent,
+            outcome="drop", reason="notional_inflation_guard",
+            extra={"gross_target": gross_target},
+        )
         return
 
     if not reduce_only:
@@ -4418,6 +4667,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
             )
         except Exception:
             LOG.warning("[REQUEST_AUDIT] publish_order_audit failed for %s (dry_run)", symbol, exc_info=True)
+        _router_dispatch_trace(
+            "dropped_pre_dispatch", intent,
+            outcome="drop", reason="dry_run",
+            extra={"gross_target": gross_target},
+        )
         return
 
     LOG.info("[executor] SEND_ORDER %s %s payload=%s meta=%s", symbol, side, payload_view, meta)
@@ -4442,7 +4696,20 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
     router_metrics: Optional[Dict[str, Any]] = None
 
     if force_direct_send:
+        _router_dispatch_trace(
+            "dispatch_called", intent,
+            outcome="ok", reason="force_direct_send_flip_open",
+            extra={
+                "router_path": "force_direct",
+                "qty": payload.get("quantity"),
+                "type": payload.get("type"),
+            },
+        )
         try:
+            _router_dispatch_trace(
+                "exchange_submit_attempted", intent,
+                extra={"router_path": "force_direct"},
+            )
             resp = _dispatch_local(payload)
             router_metrics = {
                 "attempt_id": attempt_id,
@@ -4470,6 +4737,11 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
         except Exception as exc:
             router_error = str(exc)
             LOG.error("[executor] flip open send_failed %s %s", symbol, exc)
+            _router_dispatch_trace(
+                "exchange_submit_failed", intent,
+                outcome="error", reason=f"force_direct_exception:{exc}",
+                extra={"router_path": "force_direct", "exception_class": exc.__class__.__name__},
+            )
             return
         try:
             publish_order_audit(
@@ -4528,15 +4800,45 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
         )
         if maker_ctx_enabled:
             router_payload["route"] = "maker_first"
+        _router_dispatch_trace(
+            "router_route_called", intent,
+            extra={
+                "router_path": "_route_intent",
+                "maker_first": bool(maker_ctx_enabled),
+                "policy_quality": policy.quality,
+                "policy_maker_first": policy.maker_first,
+                "policy_reason": policy.reason,
+                "qty": payload.get("quantity"),
+                "type": payload.get("type"),
+            },
+        )
         try:
             result, router_metrics = _route_intent(router_payload, attempt_id)
         except Exception as exc:
             router_error = str(exc)
+            _router_dispatch_trace(
+                "exchange_submit_failed", intent,
+                outcome="error", reason=f"route_intent_exception:{exc}",
+                extra={"router_path": "_route_intent", "exception_class": exc.__class__.__name__},
+            )
         else:
             if result.get("accepted"):
                 resp = result.get("raw") or {}
+                _router_dispatch_trace(
+                    "exchange_submit_success", intent,
+                    extra={
+                        "router_path": "_route_intent",
+                        "order_id": resp.get("orderId"),
+                        "status": resp.get("status"),
+                    },
+                )
             else:
                 router_error = str(result.get("reason") or "router_reject")
+                _router_dispatch_trace(
+                    "exchange_submit_failed", intent,
+                    outcome="reject", reason=f"router_reject:{router_error}",
+                    extra={"router_path": "_route_intent", "result": dict(result) if isinstance(result, Mapping) else None},
+                )
     elif _route_order is not None and not force_direct_send:
         router_intent = {
             **intent,
@@ -4569,15 +4871,45 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
                     "maker_qty": norm_qty,
                 }
             )
+        _router_dispatch_trace(
+            "router_route_called", intent,
+            extra={
+                "router_path": "_route_order",
+                "maker_first": bool(maker_ctx_enabled),
+                "policy_quality": policy.quality,
+                "policy_maker_first": policy.maker_first,
+                "policy_reason": policy.reason,
+                "qty": payload.get("quantity"),
+                "type": payload.get("type"),
+            },
+        )
         try:
             result = _route_order(router_intent, router_ctx, DRY_RUN)
         except Exception as exc:
             router_error = str(exc)
+            _router_dispatch_trace(
+                "exchange_submit_failed", intent,
+                outcome="error", reason=f"route_order_exception:{exc}",
+                extra={"router_path": "_route_order", "exception_class": exc.__class__.__name__},
+            )
         else:
             if result.get("accepted"):
                 resp = result.get("raw") or {}
+                _router_dispatch_trace(
+                    "exchange_submit_success", intent,
+                    extra={
+                        "router_path": "_route_order",
+                        "order_id": resp.get("orderId"),
+                        "status": resp.get("status"),
+                    },
+                )
             else:
                 router_error = str(result.get("reason") or "router_reject")
+                _router_dispatch_trace(
+                    "exchange_submit_failed", intent,
+                    outcome="reject", reason=f"router_reject:{router_error}",
+                    extra={"router_path": "_route_order", "result": dict(result) if isinstance(result, Mapping) else None},
+                )
 
     if not resp:
         if router_error and not force_direct_send:
@@ -4611,7 +4943,24 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
                     maker_result.is_maker,
                     maker_result.rejections,
                 )
+                _router_dispatch_trace(
+                    "exchange_submit_success", intent,
+                    extra={
+                        "router_path": "maker_first_fallback",
+                        "is_maker": maker_result.is_maker,
+                        "rejections": maker_result.rejections,
+                    },
+                )
     if not resp:
+        _router_dispatch_trace(
+            "dispatch_called", intent,
+            extra={
+                "router_path": "dispatch_with_retry",
+                "router_available": _route_intent is not None or _route_order is not None,
+                "force_direct_send": force_direct_send,
+                "router_error": router_error,
+            },
+        )
         _retry_ctx = _DispatchRetryContext(
             symbol=symbol,
             side=side,
@@ -4629,8 +4978,21 @@ def _send_order(state: ExecutorState, intent: Dict[str, Any], *, skip_flip: bool
         )
         _retry_result = _dispatch_with_retry(_dispatch_local, payload, _retry_ctx)
         if _retry_result is None:
+            _router_dispatch_trace(
+                "exchange_submit_failed", intent,
+                outcome="error", reason="dispatch_with_retry_returned_none",
+                extra={"router_path": "dispatch_with_retry"},
+            )
             return
         resp = _retry_result
+        _router_dispatch_trace(
+            "exchange_submit_success", intent,
+            extra={
+                "router_path": "dispatch_with_retry",
+                "order_id": resp.get("orderId") if isinstance(resp, Mapping) else None,
+                "status": resp.get("status") if isinstance(resp, Mapping) else None,
+            },
+        )
 
     latency_ms = max(0.0, (time.monotonic() - attempt_start_monotonic) * 1000.0)
 
@@ -5994,12 +6356,15 @@ def _loop_once(state: ExecutorState, i: int) -> None:
         submitted = 0
         for idx, raw_intent in enumerate(intents_raw):
             intent = _normalize_intent(raw_intent)
+            _hydra_route_trace("intents_raw_seen", intent)
             symbol = cast(Optional[str], intent.get("symbol"))
             if not symbol:
                 LOG.warning("[screener] missing symbol in intent %s", intent)
+                _hydra_route_trace("dropped_pre_send_order", intent, outcome="drop", reason="missing_symbol")
                 continue
             now_ts = time.time()
             if _symbol_on_cooldown(symbol, now_ts):
+                _hydra_route_trace("dropped_pre_send_order", intent, outcome="drop", reason="cooldown")
                 continue
 
             # --- Phase 4 Commit 5: ECS Selector (authoritative) ---
@@ -6099,14 +6464,23 @@ def _loop_once(state: ExecutorState, i: int) -> None:
                         pass  # FPS shadow must never block execution
 
                     if _ecs_result["selected"] is None:
+                        _hydra_route_trace(
+                            "dropped_pre_send_order", intent, outcome="drop",
+                            reason=f"ecs_rejected:{_ecs_result.get('selection_reason','')}",
+                        )
                         continue  # No candidate passed — skip this intent
                 except Exception as _ecs_err:
                     LOG.warning("[ecs_selector] fail-open, skipping intent: %s", _ecs_err)
+                    _hydra_route_trace("dropped_pre_send_order", intent, outcome="drop", reason="ecs_exception")
                     continue  # No legacy fallback — skip on selector failure
 
             veto_reasons = _coerce_veto_reasons(intent.get("veto"))
             if veto_reasons:
                 _publish_veto_exec(symbol, veto_reasons, intent)
+                _hydra_route_trace(
+                    "dropped_pre_send_order", intent, outcome="drop",
+                    reason=f"intent_veto:{','.join(veto_reasons)[:80]}",
+                )
                 continue
 
             attempt_id = mk_id("sig")
@@ -6143,6 +6517,10 @@ def _loop_once(state: ExecutorState, i: int) -> None:
                     symbol,
                     ",".join(doctor_verdict.get("reasons", [])),
                 )
+                _hydra_route_trace(
+                    "dropped_pre_send_order", intent, outcome="drop",
+                    reason=f"signal_doctor:{','.join(doctor_verdict.get('reasons', []))[:80]}",
+                )
                 continue
 
             submitted += 1
@@ -6155,6 +6533,7 @@ def _loop_once(state: ExecutorState, i: int) -> None:
                 intent_with_attempt.pop("_fallback", None)
                 intent_with_attempt["attempt_id"] = attempt_id
                 _FALLBACK_TELEMETRY.record_attempt(intent_with_attempt)
+                _hydra_route_trace("send_order_reached", intent_with_attempt)
                 _send_order(state, intent_with_attempt)
             except Exception as exc:
                 LOG.error("[executor] failed to send intent %s %s", symbol, exc)

--- a/execution/hybrid_component_propagation.py
+++ b/execution/hybrid_component_propagation.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from execution.log_utils import append_jsonl
+
+_LOG_PATH = Path("logs/execution/hybrid_component_propagation.jsonl")
+_TS_BUCKET_S = 300
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except Exception:
+        return None
+
+
+def _safe_ts(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        if isinstance(value, (int, float)):
+            t = float(value)
+            return t / 1000.0 if t > 1e12 else t
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+    return None
+
+
+def _norm_side(value: Any) -> str:
+    if value is None:
+        return ""
+    s = str(value).strip().upper()
+    if s in ("BUY", "LONG"):
+        return "LONG"
+    if s in ("SELL", "SHORT"):
+        return "SHORT"
+    return s
+
+
+def _stable_correlation_key(payload: Mapping[str, Any], *, strategy: str, source_head: str) -> str:
+    symbol = str(payload.get("symbol", "") or "").upper()
+    side = _norm_side(
+        payload.get("side")
+        or payload.get("signal")
+        or payload.get("direction")
+        or payload.get("net_side")
+        or payload.get("positionSide")
+    )
+    strat = str(strategy or payload.get("strategy") or payload.get("source") or "")
+    head = str(source_head or payload.get("source_head") or "")
+    score = _safe_float(payload.get("hybrid_score"))
+    if score is None:
+        score = _safe_float(payload.get("score"))
+    nav_pct = _safe_float(payload.get("nav_pct"))
+    if nav_pct is None:
+        meta = payload.get("metadata")
+        if isinstance(meta, Mapping):
+            nav_pct = _safe_float(meta.get("nav_pct"))
+
+    ts_source = (
+        _safe_ts(payload.get("signal_ts"))
+        or _safe_ts(payload.get("local_ts"))
+        or _safe_ts(payload.get("ts"))
+        or time.time()
+    )
+    ts_bucket = int(ts_source // _TS_BUCKET_S)
+
+    raw = "|".join(
+        [
+            symbol,
+            side,
+            strat,
+            head,
+            "" if score is None else f"{score:.6f}",
+            "" if nav_pct is None else f"{nav_pct:.6f}",
+            str(ts_bucket),
+        ]
+    )
+    return "corr_" + hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def trace_hybrid_component_propagation(
+    *,
+    origin_stage: str,
+    intent: Optional[Mapping[str, Any]] = None,
+    symbol: str = "",
+    intent_id: str = "",
+    strategy: str = "",
+    source_head: str = "",
+    merge_path: str = "",
+    intent_type: str = "",
+    hybrid_components: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """Append a fail-open telemetry record for hybrid component propagation.
+
+    This function is observability-only and must never affect execution flow.
+    """
+    try:
+        payload = dict(intent or {})
+        comp = dict(hybrid_components or payload.get("hybrid_components") or {})
+        keys = sorted(str(k) for k in comp.keys())
+        intent_id_val = intent_id or str(payload.get("intent_id") or payload.get("attempt_id") or "")
+        intent_id_present = bool(intent_id_val)
+        correlation_key = intent_id_val if intent_id_present else _stable_correlation_key(
+            payload,
+            strategy=strategy,
+            source_head=source_head,
+        )
+        rec = {
+            "ts": time.time(),
+            "symbol": symbol or str(payload.get("symbol", "") or "").upper(),
+            "intent_id": intent_id_val,
+            "intent_id_present": intent_id_present,
+            "correlation_key": correlation_key,
+            "strategy": strategy or str(payload.get("strategy") or payload.get("source") or ""),
+            "source_head": source_head or str(payload.get("source_head") or ""),
+            "origin_stage": origin_stage,
+            "has_hybrid_components": bool(comp),
+            "hybrid_component_keys": keys,
+            "hybrid_expectancy": _safe_float(comp.get("expectancy")),
+            "merge_path": merge_path,
+            "intent_type": intent_type or str(payload.get("type") or payload.get("event_type") or ""),
+        }
+        append_jsonl(_LOG_PATH, rec)
+    except Exception:
+        pass
+
+
+__all__ = ["trace_hybrid_component_propagation"]

--- a/execution/hydra_integration.py
+++ b/execution/hydra_integration.py
@@ -33,6 +33,7 @@ from execution.hydra_engine import (
     hydra_merged_intent_to_execution_intent,
     is_hydra_enabled,
 )
+from execution.hybrid_component_propagation import trace_hybrid_component_propagation
 
 _LOG = logging.getLogger(__name__)
 
@@ -151,14 +152,57 @@ def convert_hydra_intents_to_execution(
     """
     execution_intents = []
 
+    # Telemetry helper (fail-open, append-only)
+    def _route_trace(stage: str, outcome: str, reason: str, **fields: Any) -> None:
+        try:
+            import time as _time
+            from execution.log_utils import append_jsonl as _aj
+            rec: Dict[str, Any] = {
+                "ts": _time.time(),
+                "stage": stage,
+                "outcome": outcome,
+                "reason": reason,
+            }
+            rec.update(fields)
+            _aj(Path("logs/execution/hydra_route_trace.jsonl"), rec)
+        except Exception:
+            pass
+
     for merged in merged_intents:
         if isinstance(merged, dict):
             symbol = merged.get("symbol", "")
+            net_side = merged.get("net_side", "")
+            nav_pct_v = merged.get("nav_pct", 0.0)
+            score_v = merged.get("score", 0.0)
+            heads_v = merged.get("heads", []) or []
         else:
             symbol = merged.symbol
+            net_side = getattr(merged, "net_side", "")
+            nav_pct_v = getattr(merged, "nav_pct", 0.0)
+            score_v = getattr(merged, "score", 0.0)
+            heads_v = getattr(merged, "heads", []) or []
+        source_head_v = heads_v[0] if heads_v else None
 
         price = prices.get(symbol, 0.0)
+        projected_notional_v = float(nav_usd or 0.0) * float(nav_pct_v or 0.0)
+
+        _common = {
+            "symbol": symbol,
+            "side": net_side,
+            "intent_id": None,
+            "source_head": source_head_v,
+            "strategy": "hydra",
+            "score": score_v,
+            "nav_pct": nav_pct_v,
+            "projected_notional": projected_notional_v,
+        }
+        _route_trace("merged_intent_seen", "ok", "", **_common)
+
         if price <= 0:
+            _route_trace(
+                "dropped_pre_intents_raw", "drop", "no_price",
+                **{**_common, "price_hint": price},
+            )
             continue
 
         intent = hydra_merged_intent_to_execution_intent(merged, nav_usd, price)
@@ -166,6 +210,15 @@ def convert_hydra_intents_to_execution(
             intent.setdefault("price", price)
             intent.setdefault("gross_usd", intent.get("notional_usd", 0.0))
             execution_intents.append(intent)
+            _route_trace(
+                "converted_to_execution_intent", "ok", "",
+                **{**_common, "projected_notional": float(intent.get("notional_usd") or projected_notional_v)},
+            )
+        else:
+            _route_trace(
+                "dropped_pre_intents_raw", "drop", "flat_or_zero_navpct",
+                **_common,
+            )
 
     return execution_intents
 
@@ -247,9 +300,25 @@ def merge_with_single_strategy_intents(
         Merged list of intents
     """
     if not hydra_intents:
+        for _lg in legacy_intents:
+            trace_hybrid_component_propagation(
+                origin_stage="legacy_merged",
+                intent=_lg,
+                source_head=str((_lg or {}).get("source_head", "") or ""),
+                merge_path="legacy_only_fastpath",
+                intent_type="merged_intent",
+            )
         return legacy_intents
 
     if not legacy_intents:
+        for _h in hydra_intents:
+            trace_hybrid_component_propagation(
+                origin_stage="hydra_merged",
+                intent=_h,
+                source_head=str((_h or {}).get("source_head", "") or ""),
+                merge_path="hydra_only_fastpath",
+                intent_type="merged_intent",
+            )
         return hydra_intents
 
     # Index both sides by symbol
@@ -317,6 +386,13 @@ def merge_with_single_strategy_intents(
                     primary[_spk] = fallback[_spk]
 
             merged.append(primary)
+            trace_hybrid_component_propagation(
+                origin_stage="hydra_merged" if primary is h else "legacy_merged",
+                intent=primary,
+                source_head=str(primary.get("source_head", "") or ""),
+                merge_path="conflict_selected_hydra" if primary is h else "conflict_selected_legacy",
+                intent_type="merged_intent",
+            )
             _selected_scores.append(_intent_score(primary))
             _rejected_scores.append(_intent_score(fallback))
             _LOG.debug(
@@ -326,8 +402,22 @@ def merge_with_single_strategy_intents(
             )
         elif h:
             merged.append(h)
+            trace_hybrid_component_propagation(
+                origin_stage="hydra_merged",
+                intent=h,
+                source_head=str(h.get("source_head", "") or ""),
+                merge_path="hydra_only",
+                intent_type="merged_intent",
+            )
         else:
             merged.append(lg)  # type: ignore[arg-type]
+            trace_hybrid_component_propagation(
+                origin_stage="legacy_merged",
+                intent=lg,  # type: ignore[arg-type]
+                source_head=str((lg or {}).get("source_head", "") or ""),
+                merge_path="legacy_only",
+                intent_type="merged_intent",
+            )
 
     if _conflicts:
         _avg_sel = sum(_selected_scores) / len(_selected_scores)

--- a/execution/signal_screener.py
+++ b/execution/signal_screener.py
@@ -58,6 +58,7 @@ from execution.intel.symbol_score_v6 import (
     rank_intents_by_hybrid_score,
 )
 from execution.diagnostics_metrics import record_signal_emitted
+from execution.hybrid_component_propagation import trace_hybrid_component_propagation
 
 # v7.5_B2: Router quality imports
 try:
@@ -1453,6 +1454,18 @@ def generate_signals_from_config() -> Iterable[Dict[str, Any]]:
                             _conviction_cfg = None
                     
                     for result in ranked_results:
+                        _result_map = result if isinstance(result, dict) else {}
+                        trace_hybrid_component_propagation(
+                            origin_stage="ranked_result_created",
+                            intent=_result_map.get("intent"),
+                            symbol=str(_result_map.get("symbol", "") or "").upper(),
+                            strategy="screener_hybrid_rank",
+                            source_head=str(_result_map.get("source_head", "") or ""),
+                            merge_path="rank_by_hybrid",
+                            intent_type="ranked_result",
+                            hybrid_components=_result_map.get("components"),
+                        )
+
                         # Get original intent and add hybrid_score metadata
                         intent = result.get("intent", {})
                         symbol = str(intent.get("symbol", "")).upper()
@@ -1494,6 +1507,14 @@ def generate_signals_from_config() -> Iterable[Dict[str, Any]]:
                         intent["hybrid_carry_details"] = result.get("carry_details", {})
                         intent["router_quality_score"] = rq_score
                         intent["rv_momentum_score"] = rv_score_val
+                        trace_hybrid_component_propagation(
+                            origin_stage="intent_constructed",
+                            intent=intent,
+                            strategy="screener_hybrid_rank",
+                            source_head=str(intent.get("source_head", "") or ""),
+                            merge_path="rank_by_hybrid",
+                            intent_type="execution_intent_candidate",
+                        )
                         
                         # v7.9_C1: Compute conviction score + band for every ranked intent
                         # This ensures the executor's conviction gate (min_entry_band) can pass.

--- a/tests/unit/test_fee_gate_bug_a_source_whitelist.py
+++ b/tests/unit/test_fee_gate_bug_a_source_whitelist.py
@@ -1,0 +1,216 @@
+"""
+v7.9-FG-A — Fee gate edge-source whitelist (Bug A).
+
+Regression test for the field-source mismatch where the direct-edge path
+in `_check_fee_edge_gate` only fired for `intent_expected_edge`, silently
+dropping `hybrid_components.expectancy` and `metadata.expectancy` into
+the ATR fallback path.
+
+Tests:
+  1. hybrid_expectancy present  → direct edge path used
+  2. metadata_expectancy present → direct edge path used
+  3. no expectancy              → ATR fallback still used
+  4. fee threshold unchanged    → numeric parity with existing config
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---- Test environment ------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _safe_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BINANCE_TESTNET", "1")
+    monkeypatch.setenv("DRY_RUN", "1")
+    monkeypatch.setenv("EXECUTOR_ONCE", "1")
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch):
+    """Capture the TrueEdgeResult passed into the fee gate.
+
+    The executor calls `check_fee_edge_v2(_te_result)` with the
+    TrueEdgeResult it constructed.  We patch that symbol to (a) record
+    the TrueEdgeResult and (b) return an `(allowed, details)` tuple so
+    the caller does not try to log/veto.
+    """
+    import execution.fee_gate as fg
+    import execution.true_edge as te
+
+    box: dict = {"te": None, "calls": 0}
+
+    def _fake_check_fee_edge_v2(te_result):
+        box["te"] = te_result
+        box["calls"] += 1
+        return True, {"gate_status": "pass", "shortfall_usd": 0.0}
+
+    monkeypatch.setattr(fg, "check_fee_edge_v2", _fake_check_fee_edge_v2)
+
+    # Also stub structured event writer to keep test side-effect free.
+    import execution.executor_live as el
+
+    monkeypatch.setattr(
+        el, "_record_structured_event", lambda *a, **k: None, raising=True
+    )
+
+    # Force compute_true_edge to a deterministic ATR-path result.
+    def _fake_compute_true_edge(
+        confidence: float,
+        price: float,
+        atr,
+        notional_usd: float,
+        timeframe=None,
+    ):
+        return te.TrueEdgeResult(
+            expected_edge_pct=0.0001,
+            expected_edge_usd=notional_usd * 0.0001,
+            atr_pct=0.001,
+            k_atr=0.6,
+            adv=0.0,
+            confidence=confidence,
+            notional_usd=notional_usd,
+            source="atr_conf_v1",
+        )
+
+    monkeypatch.setattr(te, "compute_true_edge", _fake_compute_true_edge)
+    # The function does `from execution.true_edge import compute_true_edge`
+    # at call time, so patching the source module is sufficient.
+
+    return box
+
+
+def _call_gate(intent: dict, *, gross_target: float = 200.0):
+    from execution.executor_live import _check_fee_edge_gate
+
+    return _check_fee_edge_gate(
+        intent=intent,
+        symbol_upper="ETHUSDT",
+        side="LONG",
+        price=2000.0,
+        price_hint=2000.0,
+        gross_target=gross_target,
+        intent_id="test_intent",
+        attempt_id="test_attempt",
+    )
+
+
+# ---- Test 1: hybrid_expectancy → direct path ------------------------------
+
+def test_hybrid_expectancy_uses_direct_edge_path(captured):
+    """Bug A regression: hybrid_components.expectancy must hit direct path."""
+    intent = {
+        "symbol": "ETHUSDT",
+        "expected_edge": 0.0,                       # absent at top level
+        "hybrid_components": {"expectancy": 0.05},  # 5% expectancy
+        "confidence": 0.7,
+    }
+    allowed = _call_gate(intent)
+    assert captured["calls"] == 1
+    te = captured["te"]
+    assert te is not None
+    # Direct path tags TrueEdgeResult source with the resolved field name.
+    assert te.source == "hybrid_expectancy", (
+        f"Expected direct-edge path (source='hybrid_expectancy'), "
+        f"got source={te.source!r} — Bug A regression"
+    )
+    # Direct path uses the resolved edge, not ATR.
+    assert te.expected_edge_pct == pytest.approx(0.05, rel=1e-6)
+    assert te.expected_edge_usd == pytest.approx(200.0 * 0.05, rel=1e-6)
+    assert te.atr_pct == 0.0
+    assert allowed is True  # stubbed v2 returns True
+
+
+# ---- Test 2: metadata_expectancy → direct path ----------------------------
+
+def test_metadata_expectancy_uses_direct_edge_path(captured):
+    """Bug A regression: metadata.expectancy must hit direct path."""
+    intent = {
+        "symbol": "ETHUSDT",
+        "expected_edge": 0.0,
+        "hybrid_components": {},
+        "metadata": {"expectancy": 0.04},
+        "confidence": 0.7,
+    }
+    allowed = _call_gate(intent)
+    assert captured["calls"] == 1
+    te = captured["te"]
+    assert te is not None
+    assert te.source == "metadata_expectancy", (
+        f"Expected direct-edge path (source='metadata_expectancy'), "
+        f"got source={te.source!r} — Bug A regression"
+    )
+    assert te.expected_edge_pct == pytest.approx(0.04, rel=1e-6)
+    assert te.atr_pct == 0.0
+    assert allowed is True
+
+
+# ---- Test 3: no expectancy → ATR fallback ---------------------------------
+
+def test_no_expectancy_uses_atr_fallback(captured):
+    """Backwards compatibility: no edge anywhere → ATR fallback unchanged."""
+    intent = {
+        "symbol": "ETHUSDT",
+        "expected_edge": 0.0,
+        "hybrid_components": {"expectancy": 0.0},
+        "metadata": {"expectancy": 0.0},
+        "confidence": 0.0,
+    }
+    _call_gate(intent)
+    assert captured["calls"] == 1
+    te = captured["te"]
+    assert te is not None
+    # Fallback path is tagged "atr_conf_v1" by compute_true_edge.
+    assert te.source == "atr_conf_v1", (
+        f"Expected ATR fallback (source='atr_conf_v1'), got {te.source!r}"
+    )
+    # ATR fields populated by the (stubbed) ATR model.
+    assert te.atr_pct > 0.0
+
+
+# ---- Test 4: top-level expected_edge still wins (priority) ----------------
+
+def test_top_level_expected_edge_takes_priority(captured):
+    """Priority: intent['expected_edge'] beats hybrid and metadata."""
+    intent = {
+        "symbol": "ETHUSDT",
+        "expected_edge": 0.10,
+        "hybrid_components": {"expectancy": 0.05},
+        "metadata": {"expectancy": 0.04},
+        "confidence": 0.7,
+    }
+    _call_gate(intent)
+    te = captured["te"]
+    assert te is not None
+    assert te.source == "intent_expected_edge"
+    assert te.expected_edge_pct == pytest.approx(0.10, rel=1e-6)
+
+
+# ---- Test 5: fee threshold unchanged --------------------------------------
+
+def test_fee_threshold_config_unchanged():
+    """The Bug A fix does not modify any fee gate threshold or buffer."""
+    from execution.fee_gate import FeeGateConfig, load_fee_gate_config
+
+    cfg = load_fee_gate_config()
+    assert isinstance(cfg, FeeGateConfig)
+    # Anchor the live numbers — these must not move with this patch.
+    assert cfg.taker_fee_rate == pytest.approx(0.0004, rel=1e-9)
+    assert cfg.fee_buffer_mult == pytest.approx(1.5, rel=1e-9)
+
+
+# ---- Test 6: edge cap still enforced --------------------------------------
+
+def test_intent_edge_cap_still_applied(captured):
+    """A runaway expectancy is capped at 25% on the direct path."""
+    intent = {
+        "symbol": "ETHUSDT",
+        "hybrid_components": {"expectancy": 0.99},  # would-be 99%
+        "confidence": 0.7,
+    }
+    _call_gate(intent, gross_target=1000.0)
+    te = captured["te"]
+    assert te is not None
+    assert te.source == "hybrid_expectancy"
+    assert te.expected_edge_pct == pytest.approx(0.25, rel=1e-6)
+    assert te.expected_edge_usd == pytest.approx(1000.0 * 0.25, rel=1e-6)

--- a/tests/unit/test_hybrid_component_propagation.py
+++ b/tests/unit/test_hybrid_component_propagation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def test_trace_writes_expected_fields(monkeypatch):
+    from execution import hybrid_component_propagation as hcp
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_append(path, rec):
+        captured["path"] = str(path)
+        captured["rec"] = rec
+
+    monkeypatch.setattr(hcp, "append_jsonl", _fake_append)
+    monkeypatch.setattr(hcp.time, "time", lambda: 1234.5)
+
+    intent = {
+        "symbol": "ethusdt",
+        "intent_id": "ord_abc",
+        "strategy": "hydra",
+        "source_head": "TREND",
+        "hybrid_components": {
+            "expectancy": 0.42,
+            "router": 0.7,
+        },
+        "type": "intent",
+    }
+
+    hcp.trace_hybrid_component_propagation(
+        origin_stage="executor_received",
+        intent=intent,
+        merge_path="hydra_only",
+    )
+
+    rec = captured["rec"]
+    assert captured["path"].endswith("logs/execution/hybrid_component_propagation.jsonl")
+    assert rec["ts"] == 1234.5
+    assert rec["origin_stage"] == "executor_received"
+    assert rec["symbol"] == "ETHUSDT"
+    assert rec["intent_id"] == "ord_abc"
+    assert rec["intent_id_present"] is True
+    assert rec["correlation_key"] == "ord_abc"
+    assert rec["strategy"] == "hydra"
+    assert rec["source_head"] == "TREND"
+    assert rec["has_hybrid_components"] is True
+    assert rec["hybrid_component_keys"] == ["expectancy", "router"]
+    assert rec["hybrid_expectancy"] == 0.42
+    assert rec["merge_path"] == "hydra_only"
+    assert rec["intent_type"] == "intent"
+
+
+def test_trace_is_fail_open(monkeypatch):
+    from execution import hybrid_component_propagation as hcp
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("disk unavailable")
+
+    monkeypatch.setattr(hcp, "append_jsonl", _boom)
+
+    # Must not raise
+    hcp.trace_hybrid_component_propagation(
+        origin_stage="fee_gate_received",
+        intent={"symbol": "BTCUSDT", "attempt_id": "sig_1"},
+    )
+
+
+def test_trace_emits_hashed_correlation_key_when_intent_id_missing(monkeypatch):
+    from execution import hybrid_component_propagation as hcp
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_append(path, rec):
+        captured["rec"] = rec
+
+    monkeypatch.setattr(hcp, "append_jsonl", _fake_append)
+    # Fixed fallback clock for deterministic ts_bucket
+    monkeypatch.setattr(hcp.time, "time", lambda: 1778429500.0)
+
+    # No intent_id / attempt_id provided.
+    intent = {
+        "symbol": "ETHUSDT",
+        "direction": "LONG",
+        "strategy": "hydra",
+        "source_head": "TREND",
+        "score": 0.456789,
+        "nav_pct": 0.012345,
+    }
+
+    hcp.trace_hybrid_component_propagation(
+        origin_stage="hydra_merged",
+        intent=intent,
+    )
+
+    rec = captured["rec"]
+    assert rec["intent_id"] == ""
+    assert rec["intent_id_present"] is False
+    assert isinstance(rec["correlation_key"], str)
+    assert rec["correlation_key"].startswith("corr_")
+    assert len(rec["correlation_key"]) > 8


### PR DESCRIPTION
## Summary
- Fix fee-gate source routing so `hybrid_expectancy` and `metadata_expectancy` use the direct expected-edge path.
- Add telemetry-only hybrid component propagation tracing.
- Leave Bug B behavior unchanged; trace only.

## Validation
- `ruff check .` clean
- `python -m py_compile execution/executor_live.py execution/hydra_engine.py execution/hydra_integration.py execution/signal_screener.py` passed
- `pytest -q tests/unit/test_fee_gate_bug_a_source_whitelist.py tests/unit/test_hybrid_component_propagation.py` passed: 9 passed
- `pytest -q tests/unit tests/integration --tb=short` ran; 2 manifest-audit failures due to untracked runtime/log state files under logs

## Operational result
- `hybrid_expectancy` became dominant fee-gate source post-deploy
- ETH/SOL fee-gate pass rate recovered
- Router/exchange flow resumed