### PR TITLE
Add Phase 1a signal causality audit and funding rate hypothesis test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ venv/
 nohup.out
 google-chrome-stable_current_amd64.deb
 data/ohlcv/
+data/hypothesis_a*.json
 .env
 __pycache__/
 outputs/

--- a/COMPREHENSIVE_EVALUATION_2026-05-19.md
+++ b/COMPREHENSIVE_EVALUATION_2026-05-19.md
@@ -1,0 +1,292 @@
+# Comprehensive Evaluation: GPT-Hedge — Six-Month Post-Mortem
+
+**Date:** 2026-05-19
+**Current state:** NAV $8,999.87 (−10.00%). System **HALTED** (`nav_stale_age=97s`). All subsystems idle 15+ minutes. Zero open positions.
+
+---
+
+## Executive Summary
+
+The fund lost $1,000 not because the market was unfavorable. It lost because the system was never fit to trade. Three compounding failures drove every dollar of the loss:
+
+1. **Broken wiring** — a key mismatch in the fee gate silently vetoed every single trade for at least 2.5 months
+2. **Unproven foundations** — the core signal's causal relationship to returns has never been measured; the test framework exists but the tables are blank
+3. **Complexity that concealed the damage** — 72,000 LOC of execution code, six formal audits, a falsified conviction engine, and now a Phase 5 catastrophic failure where the replay strategy trades the opposite direction from the live executor in 69% of orders
+
+---
+
+## Part 1: What the Numbers Actually Mean
+
+The NAV curve is monotonically negative from day one. There is no recovery window, no period of offsetting gains. Every data point is lower than the one before it.
+
+**Three loss sources:**
+
+| Source | Detail |
+|--------|--------|
+| Direct trade losses | All 5 documented trades closed `THESIS_INVALIDATED`. Avg net loss: −$0.43/trade |
+| Fee drag | 67,385 order attempts → 3,283 fills. Fee/PnL ratio in 3-day window: **4.02×** |
+| Slippage | Maker fill ratio: **5.26%** (target: 50%+). P95 slippage: **43.1 bps** |
+
+The reported 10.5% win rate is misleading: 660 of 692 episodes are from the pre-conviction era (Dec 2025). The conviction-era sample is 32 trades — statistically meaningless and also losing.
+
+---
+
+## Part 2: The Broken Plumbing
+
+### 2.1 Fee gate universal veto — `executor_live.py` (fixed 2026-05-10, ~2.5 months late)
+
+The fee gate read expected edge from two fields that **no upstream component ever writes to**:
+
+```python
+READ:  intent["metadata"]["expectancy"]        ← never set
+READ:  intent["metadata"]["expected_edge_pct"] ← never set
+
+ACTUAL data lives at:
+  intent["expected_edge"]                      ← signal_generator.py L342
+  intent["hybrid_components"]["expectancy"]    ← signal_screener.py L1306
+```
+
+**Result:** `expected_edge_pct = 0.0` on every intent. Every trade blocked with `$0.00 edge < $0.057 required`. The system appeared to be running — signals generated, doctrine evaluated — but the fee gate was reading from an empty dict key and vetoing everything.
+
+The bug was introduced in an intent schema refactor. It wasn't caught for at least 2.5 months because the system's "flat by design" framing (see §6.4 below) made total inactivity look like disciplined doctrine behavior.
+
+**The fee gate bug is the proximate cause of essentially the entire fund loss.**
+
+### 2.2 True edge heuristic always returns zero — `true_edge.py`
+
+Even after fixing the fee gate read path, the upstream edge value it reads is still broken:
+
+```python
+confidence_threshold = 0.5   # arbitrary, never calibrated
+adv = clamp(confidence - 0.5, 0, cap)
+# Live conviction scores: 0.41–0.44 (always below 0.5)
+# → adv = 0.0 → edge = $0.00
+```
+
+An empirical replacement (`expectancy_bridge.py`) was built and validated in shadow mode but was **never promoted to live**. This means that even with the fee gate wiring fixed, the edge input it receives is still computed by a known-broken heuristic.
+
+### 2.3 NAV desync — current halt cause (active right now)
+
+The system is halted **at this moment** because `nav_confirmed.json` uses a conditional write (only updates on successful API call) while `nav.json` writes unconditionally. When Binance API degrades even briefly, the confirmed cache goes stale >90 seconds, risk fires `NAV_STALE`, and all trading halts — even though `nav.json` is current and the executor is healthy. This is a self-inflicted halt caused by the conditional-write pattern.
+
+### 2.4 TWAP crash inflation (P0, still open)
+
+No slice state persisted. Restart after partial TWAP → re-sends all slices → 1.5–2× position size. Flagged in the April 2026 First-Strike audit. Not fixed.
+
+### 2.5 Dual-executor race (P0, still open)
+
+No PID lock: `supervisorctl restart` during slow shutdown → two executors reading same position cache → contradictory orders. Flagged in the April 2026 First-Strike audit. Not fixed.
+
+---
+
+## Part 3: The Over-Architecture Problem
+
+**The execution codebase: 72,613 LOC across 139 modules**
+
+```
+executor_live.py      6,747 LOC  ← single-file monolith
+cerberus_router.py    1,400 LOC  ← DISABLED
+sentinel_x.py         1,468 LOC  ← DISABLED
+alpha_decay.py        1,422 LOC  ← DISABLED
+alpha_miner.py        1,181 LOC  ← DISABLED
+cross_pair_engine.py  1,147 LOC  ← DISABLED
+```
+
+The over-architecture audit (`docs/OVER_ARCHITECTURE_AUDIT_2026-03-18.md`) classified every major layer:
+
+| Component | Classification | Proven edge? |
+|-----------|---------------|-------------|
+| Regime model (Sentinel-X) | TRANSFORM | No — no Brier/log-loss eval, no ablation |
+| Conviction scoring | TRANSFORM | No — deterministic sizing transform of upstream scores |
+| Doctrine kernel | CONTROL | No — constitutional guard, not alpha source |
+| Order router | CONTROL | No — execution quality, not predictive edge |
+| Cerberus/Alpha router | **DEAD** | No — disabled in config |
+
+The audit's conclusion: **"There is no reviewed component in this list that currently clears the bar for proven SIGNAL."** If `hybrid_score` lacks edge, every layer downstream is just reshaping noise.
+
+### 3.1 Conviction falsification (2026-04-12)
+
+Post-audit validation on 1,358 episodes:
+
+| Symbol | Spearman ρ | Q5−Q1 | Verdict |
+|--------|-----------|-------|---------|
+| BTCUSDT | +0.12 | **−0.44** | FAIL (all 3 criteria) |
+| ETHUSDT | +0.20 | +4.67 | FAIL (monotonicity) |
+| SOLUSDT | +0.03 | **−4.15** | FAIL (all 3 criteria) |
+
+Distribution collapsed: IQR = 0.057, 80% of scores in [0.61, 0.68]. All quintiles show negative mean PnL. Win rate across all bands: **10.1%**. Conviction frozen on 2026-04-12. **No replacement surface exists.** The system is currently trading with no primary entry-quality filter.
+
+### 3.2 Signal causality — the tables are blank
+
+The `docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md` defines a rigorous Spearman ρ test for whether `hybrid_score` predicts trade outcomes. Every result cell in the document reads `—`. The methodology was written. The passive observation logger was built. The p-value computation was implemented. **The test was never run on real data.**
+
+The foundational question — *does the signal predict returns?* — has never been answered in six months of live trading.
+
+---
+
+## Part 4: What the Audits Keep Finding
+
+| Audit | Date | Primary finding |
+|-------|------|-----------------|
+| Full Audit | 2026-02-22 | Signal-execution wiring gaps |
+| First-Strike | 2026-04-11 | 4 P0 stop-trading findings |
+| Second-Strike | 2026-04-11 | `DRY_RUN` defaults false outside `ENV=prod` |
+| Catastrophic State | 2026-04-11 | Structural gates failing at baseline |
+| Fourth-Strike Forensic | 2026-04-11 | Restart-time exit blindness; score integrity |
+| Fifth-Strike Rebuild | 2026-04-11 | Core code "intact but unverified" |
+| Sixth-Strike Hardening | 2026-04-11 | 30/60/90-day remediation backlog |
+| **Phase 5 Postmortem** | **2026-05-15** | **Replay trades opposite direction in 69.3% of orders** |
+
+Four separate critical audits on the **same day** (2026-04-11). Almost none of the P0 findings resolved before the next audit.
+
+### 4.1 Phase 5 catastrophic failure (most recent — 2026-05-15)
+
+Shadow soak comparing certified replay vs. live executor over 3,677 orders:
+
+| Metric | Value |
+|--------|-------|
+| Catastrophic direction mismatches | **2,548 (69.3%)** |
+| Direction match rate | **30.7%** |
+| Quantity bucket match rate | **0%** |
+| Replay strategy net PnL (certification) | **−$131.45** on 536 trades |
+
+Every catastrophic mismatch is a direction divergence: same symbol, same time, opposite side. Phase 5 terminated. Phase 6 denied. This is the current state of the most recent validation attempt.
+
+---
+
+## Part 5: Technical Debt Summary
+
+### Infrastructure (P0, all open except fee gate fix)
+
+- TWAP state not persisted → position inflation on crash
+- No PID lock → dual-executor race
+- Non-atomic peak state write → corrupt drawdown tracking on crash
+- `FAIL_CLOSED_ON_NAV_STALE=0` env var exists → silently disables NAV safety gate
+- NAV conditional-write desync → current active halt
+- `DRY_RUN` defaults false outside `ENV=prod`
+- Testnet overrides relax drawdown limit from 10% → 95%
+
+### Strategy (critical, all open)
+
+- `hybrid_score` causality never proven
+- Conviction falsified, no replacement
+- True edge heuristic always zero (bridge built, not promoted)
+- Replay ↔ live direction divergence (69.3%)
+- No backtest framework — all validation is live
+- 5 of 6 Hydra heads generate zero intents (only TREND used)
+
+### Code quality
+
+- `executor_live.py`: 6,747 LOC single-file monolith
+- ~7,000–8,000 LOC of disabled modules in the execution hot path
+- <10% test coverage on 40+ risk gates
+- 25+ env vars control behavior; several are dangerous
+- Silent exception swallowing in config loaders (returns `{}`)
+- Manifest tests fail on clean checkout (26 required artifacts missing)
+
+---
+
+## Part 6: Why It Went Wrong
+
+### 6.1 Built signal-last
+
+The infrastructure was constructed before answering whether the signal works. Conviction engine, regime model, doctrine kernel, 6 Hydra heads — all built before running a single Spearman ρ test.
+
+### 6.2 Complexity concealed bugs
+
+72,000 LOC of execution infrastructure made it easy for a one-line key mismatch to hide in the fee gate for 2.5 months. The system looked sophisticated. It was just big.
+
+### 6.3 Audit without remediation
+
+Six methodologically correct audits. Almost none of the P0 findings were fixed before the next audit. The most critical fix (fee gate) shipped only after the loss was complete.
+
+### 6.4 "Flatness as discipline" masked brokenness
+
+In January 2026, the extended observation report celebrated 39 days of flat as doctrine discipline: *"The system spent the majority of 39 days flat by design. This is not a failure."* That framing was correct if the system was flat by design. It was wrong when the system was flat because the fee gate was vetoing everything. The framing delayed diagnosis by weeks.
+
+### 6.5 The replay divergence is not a tuning problem
+
+69% of orders trading the opposite direction from the certified replay is not a threshold mismatch. It requires tracing the exact point where the signal generation logic diverges between the two code paths and resolving it before live trading means anything.
+
+---
+
+## Part 7: What Must Happen Before Trading Resumes
+
+### Immediate — do these first, in this order
+
+| # | Action | Est. effort |
+|---|--------|-------------|
+| 1 | Run the Spearman ρ test — populate the blank tables in the causality audit | 1 day |
+| 2 | Trace and resolve the replay ↔ live direction divergence | 2–4 days |
+| 3 | Fix NAV desync (`nav_confirmed` unconditional write + `sources_ok` flag) | 2 hours |
+| 4 | Add PID lock at executor startup | 30 min |
+| 5 | Atomic peak state write (`tempfile` + `os.replace`) | 15 min |
+| 6 | Persist TWAP slice state to disk | 2 hours |
+
+### Before scaling capital
+
+| # | Action |
+|---|--------|
+| 7 | Build minimal backtest harness (fixed seed, no lookahead, actual signal code) |
+| 8 | Remove all disabled modules from executor hot path (~7,000–8,000 LOC) |
+| 9 | Promote `expectancy_bridge.py` to replace true-edge heuristic |
+| 10 | Write tests for the 38+ untested risk gates |
+| 11 | Remove `FAIL_CLOSED_ON_NAV_STALE` env override |
+
+### Before adding any new strategy or capital
+
+- Prove signal ρ > 0.15 with p < 0.05 on the new entry surface
+- Define falsification criteria *before* deployment, not during post-mortem
+- Paper trade for ≥ 50 episodes before committing capital
+
+---
+
+## Summary
+
+The fund lost 10% in six months because:
+
+1. A fee gate read from an empty dict key for ~2.5 months, blocking all trades
+2. The upstream edge computation always returned zero regardless
+3. The system was deployed without ever proving the signal predicts returns
+4. The architecture accumulated 72,000 LOC before any of the foundational questions were answered
+5. The conviction engine was economically falsified and disabled, with no replacement
+6. The current replay validation shows 69% opposite-direction signals from the live executor
+
+**The documentation is excellent. The audits are methodologically sound. The remediation didn't happen.**
+
+Do not resume live trading until the signal causality test returns a verdict and the replay divergence is traced to its root. Both are questions that can be answered in days with the tooling that already exists in this repository.
+
+---
+
+## File Citations
+
+### Executor and Core Logic
+- `execution/executor_live.py` — fee gate read path (L~4500-4600), main loop (~6,747 LOC)
+- `execution/doctrine_kernel.py` — doctrine gating logic
+- `execution/true_edge.py` — broken edge heuristic (confidence - 0.5 threshold)
+- `execution/expectancy_bridge.py` — empirical replacement (not promoted)
+
+### Signal Generation
+- `execution/signal_generator.py:342` — actual `expected_edge` write location
+- `execution/signal_screener.py:1306` — actual `hybrid_components.expectancy` write location
+
+### Audits and Analysis
+- `docs/OVER_ARCHITECTURE_AUDIT_2026-03-18.md` — component classification (SIGNAL/TRANSFORM/CONTROL/DEAD)
+- `docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md` — blank Spearman ρ test results
+- `docs/v8_phase_5_failure_postmortem.md` — 69.3% direction mismatch findings (2026-05-15)
+
+### State Files
+- `logs/state/nav_state.json` — unconditional write
+- `logs/state/nav_confirmed.json` — conditional write (current halt cause)
+- `logs/state/positions_state.json` — live position snapshot
+- `logs/state/diagnostics.json` — system health
+
+### Config
+- `config/risk_limits.json` — per-symbol caps, global limits
+- `config/runtime.yaml` — trading window, signal gates
+- `config/strategy_config.json` — universe, per_trade_nav_pct
+
+---
+
+**Report prepared:** 2026-05-19
+**Evaluator:** Claude (Comprehensive Post-Mortem Analysis)

--- a/docs/PHASE1A_SIGNAL_AUDIT_SUMMARY.md
+++ b/docs/PHASE1A_SIGNAL_AUDIT_SUMMARY.md
@@ -1,0 +1,81 @@
+# Phase 1a Signal Audit — Remediation Memo
+
+**Date:** 2026-06-03
+**Branch:** `claude/evaluate-bot-performance-7k0VA`
+**Audit script:** `research/signal_causality_audit.py`
+**Full results:** `logs/state/signal_causality_audit.json`
+
+---
+
+## Resume status: blocked
+
+`hybrid_score` is empirically falsified on 377 scored closed episodes drawn from the live episode ledger. BTC ρ=−0.213 (p=0.027) and ETH ρ=−0.172 (p=0.049) are statistically significantly anti-predictive. Pooled ρ=−0.082 fails the pre-registered ρ>0.15 gate on all three criteria.
+
+| Criterion | Gate | Pooled | BTC | ETH | SOL |
+|-----------|------|-------:|----:|----:|----:|
+| Spearman ρ | >0.15 | −0.082 | −0.213 | −0.172 | −0.095 |
+| p-value | <0.05 | 0.112 | **0.027** | **0.049** | 0.271 |
+| Q5 − Q1 | >0 | −0.002 | — | — | — |
+| N | — | 377 | 109 | 132 | 136 |
+
+Higher `hybrid_score` on BTC and ETH predicts **worse** outcomes with statistical significance. All five quintiles show negative mean return. Hit rate across 1,037 total episodes: 10.4%. Total realized PnL: −$1,124.
+
+---
+
+## Sign flip is not the fix
+
+Inverting every signal direction (treating the score as a contrarian indicator) yields pooled ρ=+0.082 — still below the 0.15 gate — and hit rate 73.5% with per-trade gross return of +0.146%. After the ~0.08% round-trip fee floor, this is roughly breakeven. The anti-prediction is concentrated in BTC and ETH; the wider universe is noise. Flipping the sign on a broken model produces a marginally less broken model. The signal needs **redesign**, not inversion.
+
+Reproduce at any time:
+
+```bash
+python -m research.signal_causality_audit            # standard audit
+python -m research.signal_causality_audit --sign-flip  # sign-flip counterfactual
+```
+
+---
+
+## What happened to the halt diagnosis
+
+The comprehensive evaluation report (2026-05-19) attributed the system halt to `nav_stale_age=97s`, `min_notional` vetoes from the fee gate, and 1,119 `min_notional` risk vetoes. Phase 0 forensics on the production system found all three to be incorrect:
+
+- **NAV:** Fresh, `sources_ok: true`, ~10s old. No NAV bug.
+- **`min_notional` vetoes:** Periodic health probes (`notional=0.0`, `intent_id=None`), not real intents.
+- **Fee gate:** Has not been reached since 2026-05-06 because intents are vetoed upstream by doctrine.
+- **Actual halt cause:** Doctrine `VETO_ENVIRONMENT_DEGRADED` on every intent for ~8 days. Sentinel-X split MEAN_REVERT 55% / CHOPPY 45% — no dominant regime. Doctrine Law #2 ("no stable regime = no trade") is working as designed.
+
+The system is not broken. It is correctly refusing to trade in a degraded regime.
+
+---
+
+## Next valid work
+
+**Hypothesis A backtest** (funding rate extremes) is ready on the production server:
+
+```bash
+python3 -m research.funding_rate_extremes \
+  --symbols BTCUSDT ETHUSDT SOLUSDT \
+  --days 180 --horizon 4
+```
+
+Also run at `--horizon 2` and `--horizon 8` to check whether the edge is horizon-specific.
+
+Falsification criteria are pre-registered in `research/funding_rate_extremes.py` as constants and will not change after the first data run. If the hypothesis passes (ρ>0.15, p<0.05, Q5−Q1>0, fee-adjusted ρ>0) on all three symbols, proceed to paper trade design. If it fails or is conditional, redesign before re-testing on new data.
+
+**Phase 1b** (replay vs live direction divergence, 69.3% mismatch) is deferred. It is forensically useful but not a resume blocker given the signal audit result — both paths are trading on a falsified signal. Revisit after Hypothesis A produces a verdict.
+
+---
+
+## Audit reproducibility
+
+All work is committed to `claude/evaluate-bot-performance-7k0VA`:
+
+| Artifact | Path |
+|----------|------|
+| Audit script | `research/signal_causality_audit.py` |
+| Unit tests (7, all pass) | `tests/research/test_signal_causality.py` |
+| Full results JSON | `logs/state/signal_causality_audit.json` |
+| Sign-flip results | `logs/state/signal_causality_audit_signflip.json` |
+| Audit doc appendices | `docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md` |
+| Funding rate backtest | `research/funding_rate_extremes.py` |
+| Backtest tests (15, all pass) | `tests/research/test_funding_rate_extremes.py` |

--- a/docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md
+++ b/docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md
@@ -521,3 +521,116 @@ The Tier 1 test answers: "Does the signal rank outcomes in the region where it t
 The Tier 2 test — when data accumulates — answers the harder question: "Should it be trading that region at all?"
 
 Until Tier 2 data exists, any verdict issued from this audit is provisional.
+
+<!-- BEGIN: Phase 1a Verdict Appendix (auto-generated) -->
+## Appendix A — Phase 1a Verdict (auto-generated)
+
+_Generated 2026-05-19T09:55:48+00:00 — `research/signal_causality_audit.py`_
+
+**Source:** `logs/state/episode_ledger.json` (377 scored episodes of 1037 total)
+
+**Score field:** `hybrid_score`. Return = raw side-aware return on `avg_entry_price`/`avg_exit_price` (gross of fees).
+
+
+### A.1 Verdict
+
+| Criterion | Threshold | Observed | Pass? |
+|---|---|---|---|
+| Spearman $\rho$ | > 0.15 | -0.082003 | ❌ |
+| $p$-value | < 0.05 | 0.1118 | ❌ |
+| Q5 − Q1 spread | > 0.0 | -0.001999 | ❌ |
+
+**Overall verdict: `FAIL`**
+
+> Signal does not satisfy the causality gate on the current executed-trade cohort. Resume blocked on Phase 1a alone. Per `/memories/session/plan.md`, thresholds are locked — no auto-loosening. Escalate to user.
+
+
+### A.2 Quintile table (pooled)
+
+| Bucket | Score range | $\bar{S}$ | $\bar{O}$ (mean return) | Hit rate (%) | $N$ | Avg hold (hrs) | Std hold (hrs) |
+|---|---|---|---|---|---|---|---|
+| Q1 | [0.2933, 0.4184] | 0.3884 | -0.000456 | 24.0 | 75 | 0.76 | 2.547 |
+| Q2 | [0.4186, 0.4408] | 0.4297 | -0.001053 | 20.0 | 75 | 1.132 | 3.676 |
+| Q3 | [0.4412, 0.4606] | 0.4518 | -0.001258 | 40.0 | 75 | 3.497 | 10.398 |
+| Q4 | [0.4606, 0.4946] | 0.4759 | -0.002059 | 22.67 | 75 | 1.838 | 3.214 |
+| Q5 | [0.4947, 0.6011] | 0.5201 | -0.002455 | 23.38 | 77 | 1.422 | 2.837 |
+
+### A.3 Summary statistics (pooled)
+
+| Metric | Value |
+|---|---|
+| $N$ | 377 |
+| Spearman $\rho$ (raw) | -0.082003 |
+| Spearman $\rho$ $p$-value (asymptotic, two-sided) | 0.1118 |
+| Q5 − Q1 spread | -0.001999 |
+| Q5 − Q1 bootstrap $p$ (2000 iter) | 1.0000 |
+| Mean return (cohort) | -0.001461 |
+| Hit rate (%) | 25.99 |
+| Avg hold (hrs) | 1.728 |
+
+### A.4 Temporal stability
+
+| Slice | Date range | $N$ | $\rho$ | $p$ | Q5−Q1 | Slope |
+|---|---|---|---|---|---|---|
+| T1 | 2026-02-24 → 2026-03-19 | 125 | -0.047786 | 0.5946 | -0.003788 | flat |
+| T2 | 2026-03-19 → 2026-05-10 | 125 | -0.063492 | 0.4796 | -0.00144 | inverted |
+| T3 | 2026-05-10 → 2026-05-10 | 127 | 0.005787 | 0.9482 | -0.000203 | flat |
+
+### A.5 Duration confound check
+
+| Bucket | Avg hold (hrs) | Std hold (hrs) |
+|---|---|---|
+| Q1 | 0.76 | 2.547 |
+| Q5 | 1.422 | 2.837 |
+
+### A.6 Per-symbol breakdown (≥25 episodes)
+
+| Symbol | $N$ | $\rho$ | $p$ | Q5−Q1 | Hit rate (%) | Mean return |
+|---|---|---|---|---|---|---|
+| SOLUSDT | 136 | -0.094719 | 0.2711 | -0.003331 | 25.74 | -0.00207 |
+| ETHUSDT | 132 | -0.171758 | 0.0493 | -0.001616 | 25.0 | -0.00176 |
+| BTCUSDT | 109 | -0.212636 | 0.0271 | -0.00268 | 27.52 | -0.000341 |
+
+<!-- END: Phase 1a Verdict Appendix -->
+
+<!-- BEGIN: Appendix B Sign-Flip (auto-generated) -->
+## Appendix B — Sign-Flip Counterfactual (auto-generated)
+
+_Generated 2026-05-19T09:55:53+00:00 — `research/signal_causality_audit.py --sign-flip`_
+
+**Hypothesis:** If the live signal is statistically anti-predictive (Appendix A: BTC ρ=-0.213 p=0.027, ETH ρ=-0.172 p=0.049), then trading the *opposite* side of every intent would have produced positive ρ on the same episode set. This appendix tests that counterfactual on the *same closed episodes* by negating the realized return per episode (algebraically equivalent to side-inversion).
+
+**Fee assumption:** 0.080% round-trip cost per trade (approximated from sample fee/notional ratios in the ledger).
+
+
+### B.1 Verdict — flipped vs baseline
+
+| Metric | Baseline (live signal) | Sign-flipped | Δ |
+|---|---:|---:|---:|
+| Pooled ρ | -0.082003 | 0.082003 | 0.164 |
+| Pooled $p$ | 0.1118 | 0.1118 | (symmetric) |
+| Mean return | -0.001461 | 0.001461 | 0.002922 |
+| Hit rate (%) | 25.99 | 73.47 | 47.48 |
+| Q5 − Q1 | -0.001999 | 0.001999 | 0.003998 |
+| Verdict | FAIL | FAIL | — |
+
+### B.2 Per-symbol gate-pass under sign-flip
+
+| Symbol | N | Baseline ρ (p) | Flipped ρ (p) | Flipped passes ρ>0.15 & p<0.05? |
+|---|---:|---:|---:|:-:|
+| SOLUSDT | 136 | -0.094719 (0.2711) | 0.094724 (0.2711) | ❌ |
+| ETHUSDT | 132 | -0.171758 (0.0493) | 0.171758 (0.0493) | ✅ |
+| BTCUSDT | 109 | -0.212636 (0.0271) | 0.212645 (0.0271) | ✅ |
+
+### B.3 Economic implication
+
+Per-trade gross return (flipped): **+0.1461%**. Subtracting assumed round-trip fee (0.080%) → per-trade net: **+0.0661%**. Across the 377 scored episodes this corresponds to a cumulative arithmetic edge of **+24.92 bps × avg-notional**.
+
+⚠️ Caveat: this is a counterfactual on *executed* trades only (left-truncated above the score threshold). It does not prove that naive sign-flipping would have been profitable in live execution — slippage, fee tiering, position sizing and risk gates would all behave differently. The result is *evidence of anti-prediction*, not a recommendation to invert the production signal.
+
+
+### B.4 Conclusion
+
+Even under sign-flip the **pooled** ρ does not clear the 0.15 gate (observed: 0.082003, p=0.1118). Per-symbol BTC and ETH would clear the gate under inversion, but the universe-level signal does not. Interpretation: the anti-prediction is concentrated in the two highest-volume symbols; on the broader universe the signal is mostly noise. Naive inversion would not fix the model — the scoring system needs a redesign, not a sign change.
+
+<!-- END: Appendix B Sign-Flip -->

--- a/research/funding_rate_extremes.py
+++ b/research/funding_rate_extremes.py
@@ -1,0 +1,433 @@
+"""
+Hypothesis A — Funding Rate Extremes: causality test.
+
+Statement: When the 8-hour perpetual funding rate deviates beyond 2× its
+30-day rolling mean-absolute value, price mean-reverts over the following
+4 hours as carry traders unwind.
+
+Anti-signal definition:
+    anti_signal = -(fr_t / rolling_30d_mean_abs)
+    Positive anti_signal → expect positive forward return (short squeeze / long unwind)
+    Negative anti_signal → expect negative forward return (short unwind)
+
+Falsification criteria (pre-registered — do not change after first data run):
+    ρ(anti_signal, return_4h)  > +0.15   (Spearman)
+    p-value                    <  0.05
+    Q5 − Q1 quintile spread    >  0.0
+    Monotonicity ratio         ≥  0.75   (quintiles in order)
+    Fee-adjusted ρ             >  0.0
+
+Usage:
+    python -m research.funding_rate_extremes
+    python -m research.funding_rate_extremes --symbols BTCUSDT ETHUSDT --days 180 --horizon 4
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_BASE_URL = "https://fapi.binance.com"
+
+# Conservative round-trip fee assumption: mostly taker fills (0.05% each way)
+_ROUND_TRIP_FEE = 0.001
+
+# ---------------------------------------------------------------------------
+# Falsification thresholds — written before seeing any data
+# ---------------------------------------------------------------------------
+_MIN_RHO = 0.15
+_MAX_PVALUE = 0.05
+_MIN_Q5_MINUS_Q1 = 0.0
+_MIN_MONOTONICITY = 0.75
+
+# 30-day rolling window in funding events (3 per day × 30 days)
+_ROLLING_WINDOW = 90
+
+
+@dataclass
+class FundingRecord:
+    ts_ms: int
+    rate: float
+
+
+@dataclass
+class Bar:
+    ts_ms: int
+    open: float
+    close: float
+
+
+@dataclass
+class AnalysisResult:
+    symbol: str
+    n: int = 0
+    horizon_h: int = 4
+    rho: float = 0.0
+    pvalue: float = 1.0
+    q5_minus_q1: float = 0.0
+    monotonicity: float = 0.0
+    rho_fee_adj: float = 0.0
+    quintile_means: list[float] = field(default_factory=list)
+    extreme_pct: float = 0.0
+    criteria: dict[str, bool] = field(default_factory=dict)
+    verdict: str = "PENDING"
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Data fetching
+# ---------------------------------------------------------------------------
+
+def _get(path: str, params: dict) -> list | dict:
+    try:
+        import requests as _requests
+    except ImportError as exc:
+        raise RuntimeError("requests is required for data fetching: pip install requests") from exc
+    url = _BASE_URL + path
+    r = _requests.get(url, params=params, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def fetch_funding_history(symbol: str, days: int) -> list[FundingRecord]:
+    """Paginate /fapi/v1/fundingRate to get the full history window."""
+    now_ms = int(time.time() * 1000)
+    start_ms = now_ms - days * 24 * 3_600_000
+    records: list[FundingRecord] = []
+    cursor = start_ms
+
+    while True:
+        data = _get("/fapi/v1/fundingRate", {
+            "symbol": symbol,
+            "startTime": cursor,
+            "endTime": now_ms,
+            "limit": 1000,
+        })
+        if not data:
+            break
+        for row in data:
+            records.append(FundingRecord(
+                ts_ms=int(row["fundingTime"]),
+                rate=float(row["fundingRate"]),
+            ))
+        if len(data) < 1000:
+            break
+        cursor = records[-1].ts_ms + 1
+        time.sleep(0.1)
+
+    records.sort(key=lambda r: r.ts_ms)
+    return records
+
+
+def fetch_klines_range(symbol: str, interval: str, start_ms: int, end_ms: int) -> list[Bar]:
+    """Paginate /fapi/v1/klines across a time range."""
+    bars: list[Bar] = []
+    cursor = start_ms
+
+    while cursor < end_ms:
+        data = _get("/fapi/v1/klines", {
+            "symbol": symbol,
+            "interval": interval,
+            "startTime": cursor,
+            "endTime": end_ms,
+            "limit": 1500,
+        })
+        if not data:
+            break
+        for row in data:
+            bars.append(Bar(ts_ms=int(row[0]), open=float(row[1]), close=float(row[4])))
+        if len(data) < 1500:
+            break
+        cursor = bars[-1].ts_ms + 1
+        time.sleep(0.05)
+
+    # Deduplicate and sort
+    seen: set[int] = set()
+    out: list[Bar] = []
+    for b in sorted(bars, key=lambda b: b.ts_ms):
+        if b.ts_ms not in seen:
+            seen.add(b.ts_ms)
+            out.append(b)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+def _rank(vals: list[float]) -> list[float]:
+    n = len(vals)
+    indexed = sorted(range(n), key=lambda i: vals[i])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j < n - 1 and vals[indexed[j + 1]] == vals[indexed[j]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[indexed[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def spearman_rho(x: list[float], y: list[float]) -> tuple[float, float]:
+    """Return (ρ, two-tailed p-value). Uses t-approximation; no scipy required."""
+    n = len(x)
+    if n < 4:
+        return 0.0, 1.0
+
+    rx, ry = _rank(x), _rank(y)
+    d2 = sum((rx[i] - ry[i]) ** 2 for i in range(n))
+    rho = 1.0 - 6.0 * d2 / (n * (n * n - 1))
+    rho = max(-1.0, min(1.0, rho))
+
+    if abs(rho) == 1.0:
+        return rho, 0.0
+
+    t = rho * math.sqrt((n - 2) / (1.0 - rho * rho))
+
+    # Two-tailed p-value via regularised incomplete beta (Abramowitz & Stegun 26.7.8)
+    df = n - 2
+    x_val = df / (df + t * t)
+    # I_x(a, b) where a=df/2, b=1/2 — use continued fraction expansion
+    def _ibeta_cf(x_v: float, a: float, b: float, max_iter: int = 200) -> float:
+        """Regularised incomplete beta via Lentz continued fraction."""
+        if x_v <= 0:
+            return 0.0
+        if x_v >= 1:
+            return 1.0
+        lbeta = math.lgamma(a + b) - math.lgamma(a) - math.lgamma(b)
+        front = math.exp(lbeta + a * math.log(x_v) + b * math.log(1 - x_v)) / a
+        # Continued fraction (even part)
+        f, C, D = 1.0, 1.0, 0.0
+        for m in range(max_iter):
+            for step in (0, 1):
+                if m == 0 and step == 0:
+                    d = 1.0
+                elif step == 0:
+                    d = m * (b - m) * x_v / ((a + 2 * m - 1) * (a + 2 * m))
+                else:
+                    d = -(a + m) * (a + b + m) * x_v / ((a + 2 * m) * (a + 2 * m + 1))
+                D = 1.0 + d * D
+                if abs(D) < 1e-30:
+                    D = 1e-30
+                C = 1.0 + d / C
+                if abs(C) < 1e-30:
+                    C = 1e-30
+                D = 1.0 / D
+                delta = C * D
+                f *= delta
+                if abs(delta - 1.0) < 1e-10:
+                    break
+        return front * f
+
+    p_one = 0.5 * _ibeta_cf(x_val, df / 2.0, 0.5)
+    p = 2.0 * p_one
+    return rho, min(1.0, max(0.0, p))
+
+
+# ---------------------------------------------------------------------------
+# Core analysis
+# ---------------------------------------------------------------------------
+
+def analyse_symbol(symbol: str, days: int, horizon_h: int) -> AnalysisResult:
+    result = AnalysisResult(symbol=symbol, horizon_h=horizon_h)
+
+    print(f"\n{'='*60}")
+    print(f"  {symbol}  |  {days}d  |  {horizon_h}h forward return")
+    print(f"{'='*60}")
+
+    print("  Fetching funding rate history ...")
+    funding = fetch_funding_history(symbol, days)
+    print(f"  {len(funding)} funding records")
+
+    if len(funding) < _ROLLING_WINDOW + 50:
+        result.verdict = "INSUFFICIENT_DATA"
+        result.error = f"only {len(funding)} funding records"
+        return result
+
+    # Fetch 1h klines: need price at funding time and at funding time + horizon_h hours
+    first_ts = funding[_ROLLING_WINDOW].ts_ms
+    last_ts = funding[-1].ts_ms + (horizon_h + 2) * 3_600_000
+    print("  Fetching 1h klines ...")
+    bars = fetch_klines_range(symbol, "1h", first_ts - 3_600_000, last_ts)
+    print(f"  {len(bars)} hourly bars")
+
+    # Price lookup: snap to nearest 1h bar open
+    bar_open: dict[int, float] = {b.ts_ms: b.open for b in bars}
+
+    def price_at(ts_ms: int) -> Optional[float]:
+        snapped = (ts_ms // 3_600_000) * 3_600_000
+        return bar_open.get(snapped)
+
+    # Build signal / return pairs
+    signals: list[float] = []
+    returns: list[float] = []
+
+    for i in range(_ROLLING_WINDOW, len(funding)):
+        fr = funding[i].rate
+        ts = funding[i].ts_ms
+
+        window_abs = [abs(funding[j].rate) for j in range(i - _ROLLING_WINDOW, i)]
+        mean_abs = statistics.mean(window_abs)
+        if mean_abs < 1e-9:
+            continue  # degenerate window
+
+        anti_signal = -(fr / mean_abs)
+
+        px_now = price_at(ts)
+        px_fwd = price_at(ts + horizon_h * 3_600_000)
+        if px_now is None or px_fwd is None or px_now <= 0:
+            continue
+
+        signals.append(anti_signal)
+        returns.append((px_fwd - px_now) / px_now)
+
+    result.n = len(signals)
+    print(f"  Usable pairs: {result.n}")
+
+    if result.n < 50:
+        result.verdict = "INSUFFICIENT_PAIRS"
+        result.error = f"only {result.n} usable pairs"
+        return result
+
+    # Spearman ρ
+    result.rho, result.pvalue = spearman_rho(signals, returns)
+    print(f"  ρ = {result.rho:+.4f}   p = {result.pvalue:.4f}")
+
+    # Quintile analysis
+    n = result.n
+    paired = sorted(zip(signals, returns), key=lambda t: t[0])
+    q_size = n // 5
+    result.quintile_means = []
+    for q in range(5):
+        s = q * q_size
+        e = (q + 1) * q_size if q < 4 else n
+        result.quintile_means.append(statistics.mean(r for _, r in paired[s:e]))
+
+    result.q5_minus_q1 = result.quintile_means[4] - result.quintile_means[0]
+    in_order = sum(1 for i in range(4) if result.quintile_means[i] <= result.quintile_means[i + 1])
+    result.monotonicity = in_order / 4.0
+
+    qstr = "  ".join(f"{v:+.5f}" for v in result.quintile_means)
+    print(f"  Quintiles Q1→Q5: {qstr}")
+    print(f"  Q5−Q1 = {result.q5_minus_q1:+.5f}   monotonicity = {result.monotonicity:.2f}")
+
+    # Fee-adjusted ρ
+    fee_adj = [r - _ROUND_TRIP_FEE for r in returns]
+    result.rho_fee_adj, _ = spearman_rho(signals, fee_adj)
+    print(f"  Fee-adj ρ = {result.rho_fee_adj:+.4f}")
+
+    # Extreme signal fraction
+    result.extreme_pct = 100.0 * sum(1 for s in signals if abs(s) > 2.0) / n
+    print(f"  |signal| > 2σ: {result.extreme_pct:.1f}% of observations")
+
+    # Verdict
+    result.criteria = {
+        "rho_above_0.15": result.rho > _MIN_RHO,
+        "pvalue_below_0.05": result.pvalue < _MAX_PVALUE,
+        "q5_q1_positive": result.q5_minus_q1 > _MIN_Q5_MINUS_Q1,
+        "monotonicity_above_0.75": result.monotonicity >= _MIN_MONOTONICITY,
+        "fee_adj_rho_positive": result.rho_fee_adj > 0.0,
+    }
+    passed = sum(result.criteria.values())
+    result.verdict = "PASS" if passed == 5 else ("CONDITIONAL" if passed >= 3 else "FAIL")
+
+    print(f"\n  Criteria:")
+    for k, v in result.criteria.items():
+        print(f"    {'✓' if v else '✗'}  {k}")
+    print(f"\n  VERDICT: {result.verdict}  ({passed}/5)")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Hypothesis A: funding rate extremes causality test"
+    )
+    parser.add_argument("--symbols", nargs="+", default=["BTCUSDT", "ETHUSDT", "SOLUSDT"])
+    parser.add_argument("--days", type=int, default=180,
+                        help="Calendar days of history to fetch")
+    parser.add_argument("--horizon", type=int, default=4,
+                        help="Forward return horizon in hours")
+    parser.add_argument("--out", default="data/hypothesis_a_results.json",
+                        help="Path to write JSON results")
+    args = parser.parse_args()
+
+    print("\nFALSIFICATION CRITERIA (pre-registered):")
+    print(f"  ρ(anti_signal, return_{args.horizon}h)  > {_MIN_RHO}")
+    print(f"  p-value                               < {_MAX_PVALUE}")
+    print(f"  Q5 − Q1                               > {_MIN_Q5_MINUS_Q1}")
+    print(f"  Monotonicity ratio                    ≥ {_MIN_MONOTONICITY}")
+    print(f"  Fee-adjusted ρ                        > 0.0")
+    print(f"\n  Signal: anti_signal = -(fr_t / rolling_30d_mean_abs)")
+    print(f"  Rationale: high +funding → longs unwind → price falls → short earns")
+
+    results = []
+    for sym in args.symbols:
+        try:
+            r = analyse_symbol(sym, args.days, args.horizon)
+        except Exception as exc:
+            r = AnalysisResult(symbol=sym, verdict="ERROR", error=str(exc))
+            print(f"\nERROR for {sym}: {exc}")
+        results.append(r)
+
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}")
+    for r in results:
+        print(f"  {r.symbol:12s}  {r.verdict:12s}  ρ={r.rho:+.4f}  p={r.pvalue:.4f}  n={r.n}")
+
+    any_fail = any(r.verdict == "FAIL" for r in results)
+    any_error = any(r.verdict == "ERROR" for r in results)
+    all_pass = all(r.verdict == "PASS" for r in results)
+
+    print()
+    if all_pass:
+        print("HYPOTHESIS SUPPORTED — proceed to paper trade design")
+    elif any_error:
+        print("ERRORS ENCOUNTERED — fix data fetch issues before concluding")
+    elif any_fail:
+        print("HYPOTHESIS NOT SUPPORTED — do not deploy live")
+        print("Redesign signal before re-testing on new data.")
+    else:
+        print("CONDITIONAL SUPPORT — review individual criteria before proceeding")
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = [
+        {
+            "symbol": r.symbol,
+            "n": r.n,
+            "horizon_h": r.horizon_h,
+            "rho": r.rho,
+            "pvalue": r.pvalue,
+            "q5_minus_q1": r.q5_minus_q1,
+            "monotonicity": r.monotonicity,
+            "rho_fee_adj": r.rho_fee_adj,
+            "extreme_pct": r.extreme_pct,
+            "quintile_means": r.quintile_means,
+            "criteria": r.criteria,
+            "verdict": r.verdict,
+            "error": r.error,
+        }
+        for r in results
+    ]
+    with out_path.open("w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"\nResults → {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/funding_rate_extremes.py
+++ b/research/funding_rate_extremes.py
@@ -67,7 +67,9 @@ class Bar:
 class AnalysisResult:
     symbol: str
     n: int = 0
+    n_before_filter: int = 0
     horizon_h: int = 4
+    min_signal_abs: float = 0.0
     rho: float = 0.0
     pvalue: float = 1.0
     q5_minus_q1: float = 0.0
@@ -237,11 +239,12 @@ def spearman_rho(x: list[float], y: list[float]) -> tuple[float, float]:
 # Core analysis
 # ---------------------------------------------------------------------------
 
-def analyse_symbol(symbol: str, days: int, horizon_h: int) -> AnalysisResult:
-    result = AnalysisResult(symbol=symbol, horizon_h=horizon_h)
+def analyse_symbol(symbol: str, days: int, horizon_h: int, min_signal_abs: float = 0.0) -> AnalysisResult:
+    result = AnalysisResult(symbol=symbol, horizon_h=horizon_h, min_signal_abs=min_signal_abs)
 
+    filter_label = f"  |  |signal|≥{min_signal_abs}" if min_signal_abs > 0 else ""
     print(f"\n{'='*60}")
-    print(f"  {symbol}  |  {days}d  |  {horizon_h}h forward return")
+    print(f"  {symbol}  |  {days}d  |  {horizon_h}h forward return{filter_label}")
     print(f"{'='*60}")
 
     print("  Fetching funding rate history ...")
@@ -282,6 +285,9 @@ def analyse_symbol(symbol: str, days: int, horizon_h: int) -> AnalysisResult:
 
         anti_signal = -(fr / mean_abs)
 
+        if min_signal_abs > 0 and abs(anti_signal) < min_signal_abs:
+            continue
+
         px_now = price_at(ts)
         px_fwd = price_at(ts + horizon_h * 3_600_000)
         if px_now is None or px_fwd is None or px_now <= 0:
@@ -290,8 +296,12 @@ def analyse_symbol(symbol: str, days: int, horizon_h: int) -> AnalysisResult:
         signals.append(anti_signal)
         returns.append((px_fwd - px_now) / px_now)
 
+    result.n_before_filter = result.n  # placeholder — set below
     result.n = len(signals)
-    print(f"  Usable pairs: {result.n}")
+    if min_signal_abs > 0:
+        print(f"  Pairs after |signal|≥{min_signal_abs} filter: {result.n}")
+    else:
+        print(f"  Usable pairs: {result.n}")
 
     if result.n < 50:
         result.verdict = "INSUFFICIENT_PAIRS"
@@ -361,6 +371,9 @@ def main() -> None:
                         help="Calendar days of history to fetch")
     parser.add_argument("--horizon", type=int, default=4,
                         help="Forward return horizon in hours")
+    parser.add_argument("--min-signal", type=float, default=0.0,
+                        help="Only include observations where |anti_signal| >= this value "
+                             "(0 = all; 2.0 = extremes only, funding > 2× rolling mean)")
     parser.add_argument("--out", default="data/hypothesis_a_results.json",
                         help="Path to write JSON results")
     args = parser.parse_args()
@@ -373,11 +386,13 @@ def main() -> None:
     print(f"  Fee-adjusted ρ                        > 0.0")
     print(f"\n  Signal: anti_signal = -(fr_t / rolling_30d_mean_abs)")
     print(f"  Rationale: high +funding → longs unwind → price falls → short earns")
+    if args.min_signal > 0:
+        print(f"  Filter: |anti_signal| >= {args.min_signal} (extreme events only)")
 
     results = []
     for sym in args.symbols:
         try:
-            r = analyse_symbol(sym, args.days, args.horizon)
+            r = analyse_symbol(sym, args.days, args.horizon, args.min_signal)
         except Exception as exc:
             r = AnalysisResult(symbol=sym, verdict="ERROR", error=str(exc))
             print(f"\nERROR for {sym}: {exc}")
@@ -411,6 +426,7 @@ def main() -> None:
             "symbol": r.symbol,
             "n": r.n,
             "horizon_h": r.horizon_h,
+            "min_signal_abs": r.min_signal_abs,
             "rho": r.rho,
             "pvalue": r.pvalue,
             "q5_minus_q1": r.q5_minus_q1,

--- a/research/signal_causality_audit.py
+++ b/research/signal_causality_audit.py
@@ -1,0 +1,655 @@
+"""Signal-outcome causality audit (Phase 1a of resume remediation).
+
+Reads logs/state/episode_ledger.json, computes for each scored episode:
+- Spearman rho (raw) + asymptotic p-value
+- Quintile breakdown: mean score, mean return, hit rate, N, avg hold hours
+- Q5-Q1 spread + bootstrap p-value
+- Temporal stability across 3 chronological time slices
+- Duration confound check
+
+Reuses execution.hydra_monotonicity._spearman.
+
+Outputs:
+- JSON to logs/state/signal_causality_audit.json
+- Markdown verdict block appended to
+  docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md (only the new
+  "Appendix A" section; existing template tables in section 5 are
+  left unchanged).
+
+Verdict gate (from /memories/session/plan.md):
+- PASS:  pooled rho > 0.15 AND p < 0.05 AND Q5-Q1 > 0
+- FAIL:  any criterion missed
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import random
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+# Path so we can import execution.* when run as `python -m research.signal_causality_audit`
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from execution.hydra_monotonicity import _spearman  # type: ignore  # noqa: E402
+
+LEDGER_PATH = os.path.join("logs", "state", "episode_ledger.json")
+OUT_PATH = os.path.join("logs", "state", "signal_causality_audit.json")
+DOC_PATH = os.path.join("docs", "SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md")
+
+# Verdict gate thresholds (locked, no auto-loosening — see plan.md)
+RHO_GATE = 0.15
+PVAL_GATE = 0.05
+SPREAD_GATE = 0.0
+
+
+def _safe_float(val: Any) -> float:
+    if val is None:
+        return 0.0
+    try:
+        v = float(val)
+        return v if math.isfinite(v) else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _realized_return(ep: Dict[str, Any]) -> Optional[float]:
+    """Side-aware realized return (gross of fees). Excludes fee impact so the
+    test is on signal quality, not execution overhead."""
+    entry = _safe_float(ep.get("avg_entry_price"))
+    exit_ = _safe_float(ep.get("avg_exit_price"))
+    if entry <= 0 or exit_ <= 0:
+        return None
+    side = str(ep.get("side", "")).upper()
+    if side == "LONG":
+        return (exit_ - entry) / entry
+    if side == "SHORT":
+        return (entry - exit_) / entry
+    return None
+
+
+def _net_return_pct(ep: Dict[str, Any]) -> Optional[float]:
+    """Net (after-fee) return as fraction of entry notional. Reported alongside
+    raw return so we can see fee drag separately."""
+    notional = _safe_float(ep.get("entry_notional"))
+    if notional <= 0:
+        return None
+    net = _safe_float(ep.get("net_pnl"))
+    return net / notional
+
+
+def _parse_ts(ts: Any) -> Optional[float]:
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Statistics helpers
+# --------------------------------------------------------------------------- #
+
+def _normal_cdf(z: float) -> float:
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def _spearman_p_value(rho: float, n: int) -> Optional[float]:
+    """Two-sided asymptotic p-value for Spearman rho under H0: rho == 0.
+
+    For n >= 10, sqrt(n-1) * rho is approximately N(0,1) under H0.
+    For n=377 this is extremely accurate.
+    """
+    if n < 10 or rho is None:
+        return None
+    z = abs(rho) * math.sqrt(n - 1)
+    return 2.0 * (1.0 - _normal_cdf(z))
+
+
+def _quintile_table(
+    pairs: List[Tuple[float, float, float]],  # (score, return, hold_hrs)
+    n_buckets: int = 5,
+) -> List[Dict[str, Any]]:
+    """Equal-count quintile breakdown. Last bucket absorbs any remainder."""
+    if len(pairs) < n_buckets:
+        return []
+    sorted_pairs = sorted(pairs, key=lambda p: p[0])
+    n = len(sorted_pairs)
+    bucket_size = n // n_buckets
+    buckets: List[Dict[str, Any]] = []
+    for q in range(n_buckets):
+        lo = q * bucket_size
+        hi = (q + 1) * bucket_size if q < n_buckets - 1 else n
+        chunk = sorted_pairs[lo:hi]
+        if not chunk:
+            continue
+        scores = [c[0] for c in chunk]
+        rets = [c[1] for c in chunk]
+        holds = [c[2] for c in chunk if c[2] > 0]
+        mean_ret = sum(rets) / len(rets)
+        std_hold = (
+            math.sqrt(sum((h - sum(holds) / len(holds)) ** 2 for h in holds) / len(holds))
+            if len(holds) > 1
+            else 0.0
+        )
+        buckets.append(
+            {
+                "bucket": f"Q{q+1}",
+                "score_range": [round(min(scores), 4), round(max(scores), 4)],
+                "mean_score": round(sum(scores) / len(scores), 4),
+                "mean_return": round(mean_ret, 6),
+                "hit_rate_pct": round(100.0 * sum(1 for r in rets if r > 0) / len(rets), 2),
+                "n": len(rets),
+                "avg_hold_hrs": round(sum(holds) / len(holds), 3) if holds else 0.0,
+                "std_hold_hrs": round(std_hold, 3),
+            }
+        )
+    return buckets
+
+
+def _bootstrap_q5_q1_pvalue(
+    pairs: List[Tuple[float, float, float]],
+    n_iter: int = 2000,
+    seed: int = 42,
+) -> Tuple[float, float]:
+    """Bootstrap Q5-Q1 spread distribution; return (observed_spread, two_sided_p).
+
+    p is the fraction of bootstrap samples in which spread <= 0 (one-sided),
+    doubled to two-sided. Tests H0: signal does NOT predict ordering.
+    """
+    rng = random.Random(seed)
+    n = len(pairs)
+    if n < 25:
+        return 0.0, 1.0
+    observed = _quintile_table(pairs)
+    if len(observed) < 5:
+        return 0.0, 1.0
+    obs_spread = observed[-1]["mean_return"] - observed[0]["mean_return"]
+    le_zero = 0
+    for _ in range(n_iter):
+        sample = [pairs[rng.randrange(n)] for _ in range(n)]
+        bt = _quintile_table(sample)
+        if len(bt) < 5:
+            continue
+        spread = bt[-1]["mean_return"] - bt[0]["mean_return"]
+        if spread <= 0:
+            le_zero += 1
+    one_sided = le_zero / n_iter
+    return obs_spread, min(1.0, 2.0 * one_sided)
+
+
+# --------------------------------------------------------------------------- #
+# Core audit
+# --------------------------------------------------------------------------- #
+
+def _extract_pairs(
+    episodes: List[Dict[str, Any]],
+    score_field: str = "hybrid_score",
+    sign_flip: bool = False,
+) -> List[Tuple[float, float, float, float, str]]:
+    """Returns (score, raw_return, hold_hrs, entry_ts, symbol).
+
+    If sign_flip=True, returns the return that WOULD have been realized had
+    every signal traded in the opposite direction (i.e. the signal-inverted
+    counterfactual). Algebraically equivalent to negating the return field.
+    """
+    out: List[Tuple[float, float, float, float, str]] = []
+    flip_mul = -1.0 if sign_flip else 1.0
+    for ep in episodes:
+        score = _safe_float(ep.get(score_field))
+        if score <= 0:
+            continue
+        ret = _realized_return(ep)
+        if ret is None:
+            continue
+        hold = _safe_float(ep.get("duration_hours"))
+        entry_ts = _parse_ts(ep.get("entry_ts")) or 0.0
+        symbol = str(ep.get("symbol") or "UNKNOWN")
+        out.append((score, ret * flip_mul, hold, entry_ts, symbol))
+    return out
+
+
+def _audit_block(
+    pairs_full: List[Tuple[float, float, float, float, str]],
+    label: str,
+) -> Dict[str, Any]:
+    """Compute the full audit on one cohort of pairs."""
+    if not pairs_full:
+        return {"label": label, "n": 0, "verdict": "INSUFFICIENT_DATA"}
+    scores = [p[0] for p in pairs_full]
+    rets = [p[1] for p in pairs_full]
+    holds = [p[2] for p in pairs_full]
+    n = len(scores)
+
+    rho = _spearman(scores, rets)
+    p_val = _spearman_p_value(rho, n) if rho is not None else None
+
+    quintile_pairs = [(s, r, h) for s, r, h, _, _ in pairs_full]
+    quintiles = _quintile_table(quintile_pairs)
+    spread, boot_p = _bootstrap_q5_q1_pvalue(quintile_pairs)
+
+    return {
+        "label": label,
+        "n": n,
+        "rho": round(rho, 6) if rho is not None else None,
+        "rho_p_value": round(p_val, 6) if p_val is not None else None,
+        "q5_minus_q1": round(spread, 6),
+        "q5_minus_q1_bootstrap_p": round(boot_p, 4),
+        "quintiles": quintiles,
+        "mean_return": round(sum(rets) / n, 6),
+        "hit_rate_pct": round(100.0 * sum(1 for r in rets if r > 0) / n, 2),
+        "avg_hold_hrs": round(sum(h for h in holds if h > 0) / max(1, sum(1 for h in holds if h > 0)), 3),
+    }
+
+
+def _temporal_slices(
+    pairs_full: List[Tuple[float, float, float, float, str]],
+    n_slices: int = 3,
+) -> List[Dict[str, Any]]:
+    sorted_pairs = sorted(pairs_full, key=lambda p: p[3])
+    n = len(sorted_pairs)
+    if n < n_slices * 10:
+        return []
+    slice_size = n // n_slices
+    out: List[Dict[str, Any]] = []
+    for i in range(n_slices):
+        lo = i * slice_size
+        hi = (i + 1) * slice_size if i < n_slices - 1 else n
+        chunk = sorted_pairs[lo:hi]
+        ts_lo = chunk[0][3]
+        ts_hi = chunk[-1][3]
+        block = _audit_block(chunk, f"T{i+1}")
+        block["date_range"] = [
+            datetime.fromtimestamp(ts_lo, tz=timezone.utc).strftime("%Y-%m-%d"),
+            datetime.fromtimestamp(ts_hi, tz=timezone.utc).strftime("%Y-%m-%d"),
+        ]
+        # classify slope using same thresholds as hydra_monotonicity
+        rho = block.get("rho")
+        if rho is None:
+            slope = "insufficient_data"
+        elif rho > 0.15:
+            slope = "upward"
+        elif rho < -0.05:
+            slope = "inverted"
+        else:
+            slope = "flat"
+        block["slope"] = slope
+        out.append(block)
+    return out
+
+
+def run_audit(
+    ledger_path: str = LEDGER_PATH,
+    score_field: str = "hybrid_score",
+    sign_flip: bool = False,
+) -> Dict[str, Any]:
+    with open(ledger_path) as f:
+        data = json.load(f)
+    episodes = data.get("episodes") if isinstance(data, dict) else data
+    if not episodes:
+        return {"ts": time.time(), "verdict": "NO_EPISODES", "n_total": 0}
+
+    pairs = _extract_pairs(episodes, score_field=score_field, sign_flip=sign_flip)
+    pooled = _audit_block(pairs, "POOLED")
+    slices = _temporal_slices(pairs)
+
+    # Per-symbol breakdown (only symbols with enough samples)
+    by_symbol: Dict[str, List[Tuple[float, float, float, float, str]]] = {}
+    for p in pairs:
+        by_symbol.setdefault(p[4], []).append(p)
+    per_symbol = [
+        _audit_block(v, sym)
+        for sym, v in sorted(by_symbol.items(), key=lambda kv: -len(kv[1]))
+        if len(v) >= 25
+    ]
+
+    # Verdict
+    rho = pooled.get("rho")
+    p_val = pooled.get("rho_p_value")
+    spread = pooled.get("q5_minus_q1")
+    criteria = {
+        "rho_gt_0_15": bool(rho is not None and rho > RHO_GATE),
+        "p_lt_0_05": bool(p_val is not None and p_val < PVAL_GATE),
+        "spread_gt_0": bool(spread is not None and spread > SPREAD_GATE),
+    }
+    passed = all(criteria.values())
+    verdict = "PASS" if passed else "FAIL"
+
+    return {
+        "ts": time.time(),
+        "ts_iso": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "ledger_path": ledger_path,
+        "score_field": score_field,
+        "sign_flip": sign_flip,
+        "n_total_episodes": len(episodes),
+        "n_scored_episodes": len(pairs),
+        "pooled": pooled,
+        "temporal_slices": slices,
+        "per_symbol": per_symbol,
+        "gate_thresholds": {
+            "rho_min": RHO_GATE,
+            "p_max": PVAL_GATE,
+            "spread_min": SPREAD_GATE,
+        },
+        "criteria": criteria,
+        "verdict": verdict,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Markdown verdict appendix
+# --------------------------------------------------------------------------- #
+
+APPENDIX_MARKER = "\n<!-- BEGIN: Phase 1a Verdict Appendix (auto-generated) -->\n"
+APPENDIX_END = "\n<!-- END: Phase 1a Verdict Appendix -->\n"
+APPENDIX_B_MARKER = "\n<!-- BEGIN: Appendix B Sign-Flip (auto-generated) -->\n"
+APPENDIX_B_END = "\n<!-- END: Appendix B Sign-Flip -->\n"
+
+
+def _fmt_pval(p: Optional[float]) -> str:
+    if p is None:
+        return "—"
+    if p < 1e-4:
+        return f"{p:.2e}"
+    return f"{p:.4f}"
+
+
+def render_appendix(report: Dict[str, Any]) -> str:
+    lines: List[str] = []
+    lines.append("## Appendix A — Phase 1a Verdict (auto-generated)\n")
+    lines.append(f"_Generated {report['ts_iso']} — `research/signal_causality_audit.py`_\n")
+    lines.append(
+        f"**Source:** `{report['ledger_path']}` "
+        f"({report['n_scored_episodes']} scored episodes "
+        f"of {report['n_total_episodes']} total)\n"
+    )
+    lines.append(
+        f"**Score field:** `{report['score_field']}`. "
+        f"Return = raw side-aware return on `avg_entry_price`/`avg_exit_price` (gross of fees).\n"
+    )
+    lines.append("")
+    lines.append("### A.1 Verdict\n")
+    crit = report["criteria"]
+    pooled = report["pooled"]
+    lines.append("| Criterion | Threshold | Observed | Pass? |")
+    lines.append("|---|---|---|---|")
+    lines.append(
+        f"| Spearman $\\rho$ | > {RHO_GATE} | {pooled.get('rho')} | "
+        f"{'✅' if crit['rho_gt_0_15'] else '❌'} |"
+    )
+    lines.append(
+        f"| $p$-value | < {PVAL_GATE} | {_fmt_pval(pooled.get('rho_p_value'))} | "
+        f"{'✅' if crit['p_lt_0_05'] else '❌'} |"
+    )
+    lines.append(
+        f"| Q5 − Q1 spread | > {SPREAD_GATE} | {pooled.get('q5_minus_q1')} | "
+        f"{'✅' if crit['spread_gt_0'] else '❌'} |"
+    )
+    lines.append("")
+    lines.append(f"**Overall verdict: `{report['verdict']}`**\n")
+    if report["verdict"] == "FAIL":
+        lines.append(
+            "> Signal does not satisfy the causality gate on the current "
+            "executed-trade cohort. Resume blocked on Phase 1a alone. "
+            "Per `/memories/session/plan.md`, thresholds are locked — no "
+            "auto-loosening. Escalate to user.\n"
+        )
+    lines.append("")
+    lines.append("### A.2 Quintile table (pooled)\n")
+    lines.append(
+        "| Bucket | Score range | $\\bar{S}$ | $\\bar{O}$ (mean return) | "
+        "Hit rate (%) | $N$ | Avg hold (hrs) | Std hold (hrs) |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for b in pooled.get("quintiles", []):
+        sr = b["score_range"]
+        lines.append(
+            f"| {b['bucket']} | [{sr[0]}, {sr[1]}] | {b['mean_score']} | "
+            f"{b['mean_return']} | {b['hit_rate_pct']} | {b['n']} | "
+            f"{b['avg_hold_hrs']} | {b['std_hold_hrs']} |"
+        )
+    lines.append("")
+    lines.append("### A.3 Summary statistics (pooled)\n")
+    lines.append("| Metric | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| $N$ | {pooled.get('n')} |")
+    lines.append(f"| Spearman $\\rho$ (raw) | {pooled.get('rho')} |")
+    lines.append(f"| Spearman $\\rho$ $p$-value (asymptotic, two-sided) | {_fmt_pval(pooled.get('rho_p_value'))} |")
+    lines.append(f"| Q5 − Q1 spread | {pooled.get('q5_minus_q1')} |")
+    lines.append(f"| Q5 − Q1 bootstrap $p$ (2000 iter) | {_fmt_pval(pooled.get('q5_minus_q1_bootstrap_p'))} |")
+    lines.append(f"| Mean return (cohort) | {pooled.get('mean_return')} |")
+    lines.append(f"| Hit rate (%) | {pooled.get('hit_rate_pct')} |")
+    lines.append(f"| Avg hold (hrs) | {pooled.get('avg_hold_hrs')} |")
+    lines.append("")
+    lines.append("### A.4 Temporal stability\n")
+    lines.append("| Slice | Date range | $N$ | $\\rho$ | $p$ | Q5−Q1 | Slope |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for s in report.get("temporal_slices", []):
+        dr = s.get("date_range", ["—", "—"])
+        lines.append(
+            f"| {s['label']} | {dr[0]} → {dr[1]} | {s['n']} | {s.get('rho')} | "
+            f"{_fmt_pval(s.get('rho_p_value'))} | {s.get('q5_minus_q1')} | {s.get('slope')} |"
+        )
+    lines.append("")
+    lines.append("### A.5 Duration confound check\n")
+    lines.append("| Bucket | Avg hold (hrs) | Std hold (hrs) |")
+    lines.append("|---|---|---|")
+    qs = pooled.get("quintiles", [])
+    if qs:
+        for b in (qs[0], qs[-1]):
+            lines.append(f"| {b['bucket']} | {b['avg_hold_hrs']} | {b['std_hold_hrs']} |")
+    lines.append("")
+    lines.append("### A.6 Per-symbol breakdown (≥25 episodes)\n")
+    lines.append("| Symbol | $N$ | $\\rho$ | $p$ | Q5−Q1 | Hit rate (%) | Mean return |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for s in report.get("per_symbol", []):
+        lines.append(
+            f"| {s['label']} | {s['n']} | {s.get('rho')} | {_fmt_pval(s.get('rho_p_value'))} | "
+            f"{s.get('q5_minus_q1')} | {s.get('hit_rate_pct')} | {s.get('mean_return')} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_appendix(doc_path: str, appendix_md: str) -> None:
+    with open(doc_path) as f:
+        body = f.read()
+    if APPENDIX_MARKER in body:
+        # Replace existing block
+        before = body.split(APPENDIX_MARKER)[0]
+        after_split = body.split(APPENDIX_END)
+        after = after_split[1] if len(after_split) > 1 else ""
+        new_body = before + APPENDIX_MARKER + appendix_md + APPENDIX_END + after
+    else:
+        new_body = body.rstrip() + "\n" + APPENDIX_MARKER + appendix_md + APPENDIX_END
+    with open(doc_path, "w") as f:
+        f.write(new_body)
+
+
+def render_appendix_b(
+    baseline: Dict[str, Any],
+    flipped: Dict[str, Any],
+    fee_per_trade_pct: float = 0.0008,
+) -> str:
+    """Sign-flip counterfactual report.
+
+    Computes what would have happened if every signal traded the opposite
+    direction. Algebraically: rho_flipped = -rho_baseline,
+    mean_return_flipped = -mean_return_baseline. p-value is symmetric.
+    Hit rate must be recomputed (not simple complement because of zero-PnL
+    trades).
+    """
+    lines: List[str] = []
+    lines.append("## Appendix B — Sign-Flip Counterfactual (auto-generated)\n")
+    lines.append(f"_Generated {flipped['ts_iso']} — `research/signal_causality_audit.py --sign-flip`_\n")
+    lines.append(
+        "**Hypothesis:** If the live signal is statistically anti-predictive "
+        "(Appendix A: BTC ρ=-0.213 p=0.027, ETH ρ=-0.172 p=0.049), then "
+        "trading the *opposite* side of every intent would have produced "
+        "positive ρ on the same episode set. This appendix tests that "
+        "counterfactual on the *same closed episodes* by negating the "
+        "realized return per episode (algebraically equivalent to "
+        "side-inversion).\n"
+    )
+    lines.append(
+        f"**Fee assumption:** {fee_per_trade_pct*100:.3f}% round-trip cost per trade "
+        "(approximated from sample fee/notional ratios in the ledger).\n"
+    )
+    lines.append("")
+    lines.append("### B.1 Verdict — flipped vs baseline\n")
+    bp, fp = baseline["pooled"], flipped["pooled"]
+    lines.append("| Metric | Baseline (live signal) | Sign-flipped | Δ |")
+    lines.append("|---|---:|---:|---:|")
+    lines.append(f"| Pooled ρ | {bp.get('rho')} | {fp.get('rho')} | "
+                 f"{round((fp.get('rho') or 0) - (bp.get('rho') or 0), 4)} |")
+    lines.append(f"| Pooled $p$ | {_fmt_pval(bp.get('rho_p_value'))} | "
+                 f"{_fmt_pval(fp.get('rho_p_value'))} | (symmetric) |")
+    lines.append(f"| Mean return | {bp.get('mean_return')} | {fp.get('mean_return')} | "
+                 f"{round((fp.get('mean_return') or 0) - (bp.get('mean_return') or 0), 6)} |")
+    lines.append(f"| Hit rate (%) | {bp.get('hit_rate_pct')} | {fp.get('hit_rate_pct')} | "
+                 f"{round((fp.get('hit_rate_pct') or 0) - (bp.get('hit_rate_pct') or 0), 2)} |")
+    lines.append(f"| Q5 − Q1 | {bp.get('q5_minus_q1')} | {fp.get('q5_minus_q1')} | "
+                 f"{round((fp.get('q5_minus_q1') or 0) - (bp.get('q5_minus_q1') or 0), 6)} |")
+    lines.append(f"| Verdict | {baseline['verdict']} | {flipped['verdict']} | — |")
+    lines.append("")
+    lines.append("### B.2 Per-symbol gate-pass under sign-flip\n")
+    lines.append("| Symbol | N | Baseline ρ (p) | Flipped ρ (p) | Flipped passes ρ>0.15 & p<0.05? |")
+    lines.append("|---|---:|---:|---:|:-:|")
+    baseline_per_sym = {s["label"]: s for s in baseline.get("per_symbol", [])}
+    for fs in flipped.get("per_symbol", []):
+        bs = baseline_per_sym.get(fs["label"], {})
+        f_rho = fs.get("rho")
+        f_p = fs.get("rho_p_value")
+        passes = (
+            f_rho is not None and f_rho > RHO_GATE
+            and f_p is not None and f_p < PVAL_GATE
+        )
+        lines.append(
+            f"| {fs['label']} | {fs['n']} | "
+            f"{bs.get('rho')} ({_fmt_pval(bs.get('rho_p_value'))}) | "
+            f"{f_rho} ({_fmt_pval(f_p)}) | "
+            f"{'✅' if passes else '❌'} |"
+        )
+    lines.append("")
+    lines.append("### B.3 Economic implication\n")
+    mean_ret_flipped = fp.get("mean_return") or 0.0
+    net_per_trade = mean_ret_flipped - fee_per_trade_pct
+    n_eps = flipped.get("n_scored_episodes", 0)
+    lines.append(
+        f"Per-trade gross return (flipped): **{mean_ret_flipped*100:+.4f}%**. "
+        f"Subtracting assumed round-trip fee ({fee_per_trade_pct*100:.3f}%) → "
+        f"per-trade net: **{net_per_trade*100:+.4f}%**. "
+        f"Across the {n_eps} scored episodes this corresponds to a "
+        f"cumulative arithmetic edge of **{net_per_trade*100*n_eps:+.2f} bps "
+        f"× avg-notional**.\n"
+    )
+    lines.append(
+        "⚠️ Caveat: this is a counterfactual on *executed* trades only "
+        "(left-truncated above the score threshold). It does not prove that "
+        "naive sign-flipping would have been profitable in live execution — "
+        "slippage, fee tiering, position sizing and risk gates would all "
+        "behave differently. The result is *evidence of anti-prediction*, "
+        "not a recommendation to invert the production signal.\n"
+    )
+    lines.append("")
+    lines.append("### B.4 Conclusion\n")
+    pooled_passes = (
+        fp.get("rho") is not None and fp.get("rho") > RHO_GATE
+        and fp.get("rho_p_value") is not None and fp.get("rho_p_value") < PVAL_GATE
+    )
+    if pooled_passes:
+        lines.append(
+            "The flipped pooled signal **passes** the resume-gate ρ and p "
+            "criteria. The live signal contains a recoverable inverted edge. "
+            "This is a concrete remediation candidate: investigate the side-"
+            "decision logic in `execution/signal_screener.py` and the "
+            "Hydra TREND head sign convention.\n"
+        )
+    else:
+        lines.append(
+            "Even under sign-flip the **pooled** ρ does not clear the 0.15 "
+            "gate (observed: "
+            f"{fp.get('rho')}, p={_fmt_pval(fp.get('rho_p_value'))}). "
+            "Per-symbol BTC and ETH would clear the gate under inversion, "
+            "but the universe-level signal does not. Interpretation: the "
+            "anti-prediction is concentrated in the two highest-volume "
+            "symbols; on the broader universe the signal is mostly noise. "
+            "Naive inversion would not fix the model — the scoring system "
+            "needs a redesign, not a sign change.\n"
+        )
+    return "\n".join(lines)
+
+
+def write_appendix_b(doc_path: str, appendix_md: str) -> None:
+    with open(doc_path) as f:
+        body = f.read()
+    if APPENDIX_B_MARKER in body:
+        before = body.split(APPENDIX_B_MARKER)[0]
+        after_split = body.split(APPENDIX_B_END)
+        after = after_split[1] if len(after_split) > 1 else ""
+        new_body = before + APPENDIX_B_MARKER + appendix_md + APPENDIX_B_END + after
+    else:
+        new_body = body.rstrip() + "\n" + APPENDIX_B_MARKER + appendix_md + APPENDIX_B_END
+    with open(doc_path, "w") as f:
+        f.write(new_body)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Signal-outcome causality audit")
+    parser.add_argument("--ledger", default=LEDGER_PATH)
+    parser.add_argument("--out", default=OUT_PATH)
+    parser.add_argument("--doc", default=DOC_PATH)
+    parser.add_argument("--score-field", default="hybrid_score")
+    parser.add_argument("--no-doc", action="store_true", help="Skip writing markdown appendices")
+    parser.add_argument(
+        "--sign-flip",
+        action="store_true",
+        help="Also run the sign-flip counterfactual and append Appendix B",
+    )
+    args = parser.parse_args()
+
+    report = run_audit(args.ledger, score_field=args.score_field)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w") as f:
+        json.dump(report, f, indent=2, default=str)
+    print(f"[ok] wrote {args.out}")
+
+    appendix = render_appendix(report)
+    if not args.no_doc:
+        write_appendix(args.doc, appendix)
+        print(f"[ok] appended Appendix A to {args.doc}")
+
+    print(f"\nVERDICT: {report['verdict']}")
+    print(f"  rho={report['pooled'].get('rho')} "
+          f"p={report['pooled'].get('rho_p_value')} "
+          f"Q5-Q1={report['pooled'].get('q5_minus_q1')} "
+          f"(n={report['pooled'].get('n')})")
+
+    if args.sign_flip:
+        flipped = run_audit(args.ledger, score_field=args.score_field, sign_flip=True)
+        flipped_out = args.out.replace(".json", "_signflip.json")
+        with open(flipped_out, "w") as f:
+            json.dump(flipped, f, indent=2, default=str)
+        print(f"\n[ok] wrote {flipped_out}")
+        if not args.no_doc:
+            md_b = render_appendix_b(report, flipped)
+            write_appendix_b(args.doc, md_b)
+            print(f"[ok] appended Appendix B to {args.doc}")
+        print(f"\nSIGN-FLIP VERDICT: {flipped['verdict']}")
+        print(f"  rho={flipped['pooled'].get('rho')} "
+              f"p={flipped['pooled'].get('rho_p_value')} "
+              f"mean_ret={flipped['pooled'].get('mean_return')} "
+              f"hit_rate={flipped['pooled'].get('hit_rate_pct')}%")
+
+    return 0 if report["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/research/test_funding_rate_extremes.py
+++ b/tests/research/test_funding_rate_extremes.py
@@ -1,0 +1,143 @@
+"""Tests for research/funding_rate_extremes.py — unit tests only, no network calls."""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from research.funding_rate_extremes import (
+    _ROUND_TRIP_FEE,
+    AnalysisResult,
+    _rank,
+    spearman_rho,
+)
+
+
+# ---------------------------------------------------------------------------
+# _rank
+# ---------------------------------------------------------------------------
+
+def test_rank_simple_ascending():
+    assert _rank([1.0, 2.0, 3.0]) == [1.0, 2.0, 3.0]
+
+
+def test_rank_descending():
+    assert _rank([3.0, 2.0, 1.0]) == [3.0, 2.0, 1.0]
+
+
+def test_rank_ties_average():
+    # [1, 1, 3] → tied at positions 1&2 → avg rank 1.5
+    ranks = _rank([1.0, 1.0, 3.0])
+    assert ranks[0] == pytest.approx(1.5)
+    assert ranks[1] == pytest.approx(1.5)
+    assert ranks[2] == pytest.approx(3.0)
+
+
+def test_rank_all_equal():
+    ranks = _rank([5.0, 5.0, 5.0])
+    assert all(r == pytest.approx(2.0) for r in ranks)
+
+
+# ---------------------------------------------------------------------------
+# spearman_rho
+# ---------------------------------------------------------------------------
+
+def test_spearman_perfect_positive():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    rho, p = spearman_rho(x, x)
+    assert rho == pytest.approx(1.0, abs=1e-9)
+    assert p < 0.05
+
+
+def test_spearman_perfect_negative():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y = [5.0, 4.0, 3.0, 2.0, 1.0]
+    rho, p = spearman_rho(x, y)
+    assert rho == pytest.approx(-1.0, abs=1e-9)
+    assert p < 0.05
+
+
+def test_spearman_uncorrelated_p_above_threshold():
+    # Alternating pattern has near-zero Spearman correlation
+    x = list(range(10))
+    y = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    rho, p = spearman_rho(x, y)
+    # Not expecting significance here
+    assert abs(rho) < 0.7
+    assert 0.0 <= p <= 1.0
+
+
+def test_spearman_too_short_returns_zero():
+    rho, p = spearman_rho([1.0, 2.0], [2.0, 1.0])
+    assert rho == 0.0
+    assert p == 1.0
+
+
+def test_spearman_known_value():
+    # Hand-computed example: x=[1,2,3,4,5], y=[1,3,2,5,4]
+    # Rank x = [1,2,3,4,5], Rank y = [1,3,2,5,4]
+    # d = [0,-1,1,-1,1], d^2 = [0,1,1,1,1], sum=4
+    # rho = 1 - 6*4 / (5*24) = 1 - 24/120 = 0.8
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    y = [1.0, 3.0, 2.0, 5.0, 4.0]
+    rho, p = spearman_rho(x, y)
+    assert rho == pytest.approx(0.8, abs=1e-6)
+
+
+def test_spearman_p_value_significant_strong_correlation():
+    # Strong monotone relationship over n=20 should be significant
+    x = list(range(20))
+    y = [v + 0.1 * (i % 3) for i, v in enumerate(x)]
+    rho, p = spearman_rho(x, y)
+    assert rho > 0.9
+    assert p < 0.01
+
+
+def test_spearman_p_bounds():
+    x = [float(i) for i in range(30)]
+    y = list(reversed(x))
+    rho, p = spearman_rho(x, y)
+    assert 0.0 <= p <= 1.0
+    assert rho == pytest.approx(-1.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# AnalysisResult defaults and verdict logic (no network)
+# ---------------------------------------------------------------------------
+
+def test_analysis_result_defaults():
+    r = AnalysisResult(symbol="BTCUSDT")
+    assert r.verdict == "PENDING"
+    assert r.n == 0
+    assert r.rho == 0.0
+    assert r.pvalue == 1.0
+
+
+def test_fee_constant_positive():
+    assert _ROUND_TRIP_FEE > 0
+    assert _ROUND_TRIP_FEE < 0.01  # sanity: < 1%
+
+
+# ---------------------------------------------------------------------------
+# Signal direction: high positive funding → negative return (short earns)
+# ---------------------------------------------------------------------------
+
+def test_anti_signal_direction():
+    """Verify anti_signal = -(fr / mean_abs) has correct sign convention.
+    High positive funding rate should produce a negative anti_signal,
+    meaning we expect a positive return when SHORT (anti_signal > 0 → long).
+    """
+    fr = 0.001       # positive funding (longs pay)
+    mean_abs = 0.0005
+    anti_signal = -(fr / mean_abs)
+    # High positive funding → anti_signal is negative → we would NOT go long
+    # We only trade when anti_signal is extreme in either direction
+    assert anti_signal == pytest.approx(-2.0)
+
+
+def test_anti_signal_negative_funding():
+    fr = -0.001      # negative funding (shorts pay)
+    mean_abs = 0.0005
+    anti_signal = -(fr / mean_abs)
+    # Negative funding → anti_signal positive → expect price to rise (short squeeze unwind)
+    assert anti_signal == pytest.approx(2.0)

--- a/tests/research/test_funding_rate_extremes.py
+++ b/tests/research/test_funding_rate_extremes.py
@@ -141,3 +141,17 @@ def test_anti_signal_negative_funding():
     anti_signal = -(fr / mean_abs)
     # Negative funding → anti_signal positive → expect price to rise (short squeeze unwind)
     assert anti_signal == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# AnalysisResult min_signal_abs field
+# ---------------------------------------------------------------------------
+
+def test_analysis_result_min_signal_abs_default():
+    r = AnalysisResult(symbol="BTCUSDT")
+    assert r.min_signal_abs == 0.0
+
+
+def test_analysis_result_min_signal_abs_stored():
+    r = AnalysisResult(symbol="BTCUSDT", min_signal_abs=2.0)
+    assert r.min_signal_abs == 2.0

--- a/tests/research/test_signal_causality.py
+++ b/tests/research/test_signal_causality.py
@@ -1,0 +1,135 @@
+"""Sanity test for research/signal_causality_audit.py.
+
+Confirms the audit pipeline runs on a synthetic episode dataset and that
+the verdict logic responds correctly to a perfectly-predictive vs.
+random signal. Does NOT validate the live audit verdict — that lives in
+docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md Appendix A.
+
+Marked `runtime` because it imports from `execution.*` and touches the
+heavier monotonicity module path.
+"""
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, List
+
+import pytest
+
+from research.signal_causality_audit import (
+    PVAL_GATE,
+    RHO_GATE,
+    SPREAD_GATE,
+    _audit_block,
+    _extract_pairs,
+    _spearman_p_value,
+    render_appendix,
+    run_audit,
+)
+
+pytestmark = pytest.mark.runtime
+
+
+def _mk_episode(
+    epid: str,
+    symbol: str,
+    side: str,
+    entry: float,
+    exit_: float,
+    hybrid_score: float,
+    duration_hours: float = 1.0,
+    entry_ts: str = "2026-01-01T00:00:00+00:00",
+) -> Dict[str, Any]:
+    return {
+        "episode_id": epid,
+        "symbol": symbol,
+        "side": side,
+        "entry_ts": entry_ts,
+        "exit_ts": entry_ts,
+        "avg_entry_price": entry,
+        "avg_exit_price": exit_,
+        "entry_notional": entry * 1.0,
+        "net_pnl": (exit_ - entry) if side == "LONG" else (entry - exit_),
+        "duration_hours": duration_hours,
+        "hybrid_score": hybrid_score,
+    }
+
+
+def test_perfectly_predictive_signal_passes_gate() -> None:
+    """If higher hybrid_score → higher return monotonically, verdict = PASS."""
+    eps: List[Dict[str, Any]] = []
+    for i in range(100):
+        score = 0.3 + i * 0.005  # 0.30 .. 0.795
+        # Return increases with score
+        ret_pct = 0.005 + i * 0.0001
+        exit_price = 100.0 * (1.0 + ret_pct)
+        eps.append(_mk_episode(f"EP_{i:04d}", "BTCUSDT", "LONG", 100.0, exit_price, score))
+    pairs = _extract_pairs(eps)
+    assert len(pairs) == 100
+    block = _audit_block(pairs, "TEST")
+    assert block["rho"] is not None and block["rho"] > 0.95
+    assert block["rho_p_value"] is not None and block["rho_p_value"] < 1e-6
+    assert block["q5_minus_q1"] > 0
+
+
+def test_random_signal_fails_gate() -> None:
+    """Random scores → ρ ≈ 0 → verdict = FAIL."""
+    rng = random.Random(12345)
+    eps: List[Dict[str, Any]] = []
+    for i in range(200):
+        score = rng.uniform(0.30, 0.60)
+        # Returns independent of score
+        ret_pct = rng.gauss(0.0, 0.01)
+        exit_price = 100.0 * (1.0 + ret_pct)
+        eps.append(_mk_episode(f"EP_{i:04d}", "BTCUSDT", "LONG", 100.0, exit_price, score))
+    pairs = _extract_pairs(eps)
+    block = _audit_block(pairs, "TEST")
+    assert block["rho"] is not None
+    assert abs(block["rho"]) < 0.2  # Random signal: |ρ| should be small
+
+
+def test_audit_handles_empty_dataset(tmp_path) -> None:
+    p = tmp_path / "empty_ledger.json"
+    p.write_text('{"episodes": []}')
+    report = run_audit(str(p))
+    assert report["verdict"] == "NO_EPISODES"
+
+
+def test_audit_skips_zero_score_episodes(tmp_path) -> None:
+    p = tmp_path / "ledger.json"
+    eps = [
+        _mk_episode("EP_001", "BTCUSDT", "LONG", 100.0, 101.0, 0.0),  # excluded
+        _mk_episode("EP_002", "BTCUSDT", "LONG", 100.0, 101.0, 0.5),
+    ]
+    import json as _json
+    p.write_text(_json.dumps({"episodes": eps}))
+    report = run_audit(str(p))
+    assert report["n_total_episodes"] == 2
+    assert report["n_scored_episodes"] == 1
+
+
+def test_spearman_p_value_known_values() -> None:
+    # rho=0 → p=1; large rho with reasonable n → p tiny
+    assert _spearman_p_value(0.0, 100) == pytest.approx(1.0, abs=1e-9)
+    assert _spearman_p_value(0.5, 100) is not None
+    assert _spearman_p_value(0.5, 100) < 1e-5
+    assert _spearman_p_value(0.05, 5) is None  # too few samples
+
+
+def test_verdict_thresholds_are_locked() -> None:
+    """Plan.md decision: thresholds are FIXED. Guard against drift."""
+    assert RHO_GATE == 0.15
+    assert PVAL_GATE == 0.05
+    assert SPREAD_GATE == 0.0
+
+
+def test_render_appendix_produces_markdown_with_verdict(tmp_path) -> None:
+    eps = [_mk_episode(f"EP_{i:04d}", "BTCUSDT", "LONG", 100.0, 100.0 + i * 0.01, 0.3 + i * 0.003)
+           for i in range(60)]
+    p = tmp_path / "ledger.json"
+    import json as _json
+    p.write_text(_json.dumps({"episodes": eps}))
+    report = run_audit(str(p))
+    md = render_appendix(report)
+    assert "Appendix A" in md
+    assert "Verdict" in md
+    assert report["verdict"] in md


### PR DESCRIPTION
## Summary

This PR adds two new research modules for empirical validation of trading signals and hypotheses, along with comprehensive test coverage and documentation of audit results.

## Key Changes

### New Research Modules

- **`research/signal_causality_audit.py`** (655 LOC)
  - Implements Phase 1a causality audit for `hybrid_score` signal
  - Computes Spearman ρ correlation with realized returns on executed trades
  - Generates quintile breakdown, temporal stability analysis, and per-symbol statistics
  - Outputs JSON report and auto-generates Markdown verdict appendix
  - Verdict gate: ρ > 0.15 AND p < 0.05 AND Q5−Q1 > 0 (pre-registered thresholds)
  - Reuses `execution.hydra_monotonicity._spearman` for correlation computation

- **`research/funding_rate_extremes.py`** (449 LOC)
  - Implements Hypothesis A falsification test: funding rate extremes predict mean reversion
  - Fetches Binance perpetual funding rate history and 1h OHLCV data
  - Computes anti-signal = −(funding_rate / 30d_rolling_mean_abs)
  - Tests correlation with 4-hour forward returns
  - Pre-registered falsification criteria: ρ > 0.15, p < 0.05, Q5−Q1 > 0, monotonicity ≥ 0.75
  - Includes fee-adjusted correlation and extreme signal fraction analysis
  - No external dependencies beyond `requests` for data fetching

### Test Coverage

- **`tests/research/test_signal_causality.py`** (135 LOC)
  - Unit tests for audit pipeline on synthetic datasets
  - Validates verdict logic on perfectly-predictive vs. random signals
  - Tests empty dataset handling and episode filtering

- **`tests/research/test_funding_rate_extremes.py`** (157 LOC)
  - Unit tests for ranking, Spearman correlation, and p-value computation
  - No network calls; validates statistical correctness in isolation
  - Tests edge cases: ties, perfect correlation, insufficient data

### Documentation & Results

- **`docs/SIGNAL_OUTCOME_CAUSALITY_AUDIT_2026-03-18.md`** (updated)
  - Appends auto-generated Appendix A with Phase 1a verdict
  - Results on 377 scored episodes: ρ = −0.082 (p = 0.112), Q5−Q1 = −0.002
  - **Verdict: FAIL** — signal does not satisfy causality gate
  - Per-symbol breakdown shows BTC (ρ = −0.213, p = 0.027) and ETH (ρ = −0.172, p = 0.049) are statistically significantly anti-predictive

- **`docs/PHASE1A_SIGNAL_AUDIT_SUMMARY.md`** (new)
  - Remediation memo summarizing audit findings
  - Hit rate across 1,037 episodes: 10.4%
  - Sign-flip counterfactual analysis (ρ = +0.082, still below gate)
  - Recommendation: signal requires redesign, not inversion

- **`COMPREHENSIVE_EVALUATION_2026-05-19.md`** (new)
  - Six-month post-mortem analysis of fund performance
  - Root cause analysis: fee gate wiring bug (2.5 months), broken edge heuristic, NAV desync
  - Over-architecture audit findings: 72,613 LOC execution codebase with no proven signal
  - Conviction score falsification results and temporal stability analysis

### Configuration

- **`.gitignore`** (updated)
  - Added `data/hypothesis_a*.json` to exclude hypothesis test data artifacts

## Implementation Details

- **Statistics**: Asymptotic p-values for Spearman ρ (n ≥ 10), bootstrap resampling for Q5−Q1 spread (2000 iterations)
- **Data handling**: Safe float conversion

https://claude.ai/code/session_011CdFHRvBXiERRtrJWGA5PB